### PR TITLE
Creating Initial Documentation for Repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,6 @@ map generation will clear all of your changes. For more information, visit this 
 4. DO NOT make character attributes higher than 30 (40 maximum). Having a higher value than this breaks certain vanilla
 events.
         
+General Repository Information:
+
+1. If your pull request is currently a work in progress and requires more commits before review/finalization, please write in "(WIP)" at the end of your pull request title. This will have GitHub mark it as a pull request that should not be merged yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,5 +12,3 @@ events.
 General Repository Information:
 
 1. If your pull request is currently a work in progress and requires more commits before review/finalization, please write in "(WIP)" at the end of your pull request title. This will have GitHub mark it as a pull request that should not be merged yet.
-
-Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+Rules for committing changes to the respository:
+
+1. NEVER commit directly to the `master` branch. Always create a new branch upon commit and create a pull request. This
+allows us to tag all changes made to the directly and more easily track and control where things are going in and out.
+2. DO NOT change other people's lines or code without asking them directly.
+3. DO NOT change province attributes without changing Guardians of Azeroth\map\provinceDef.xls. This is because the next
+map generation will clear all of your changes. For more information, visit this link:
+        https://forum.paradoxplaza.com/forum/index.php?threads/tutorial-tool-how-to-fill-a-custom-map.697082/
+4. DO NOT make character attributes higher than 30 (40 maximum). Having a higher value than this breaks certain vanilla
+events.
+        

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,5 @@ events.
 General Repository Information:
 
 1. If your pull request is currently a work in progress and requires more commits before review/finalization, please write in "(WIP)" at the end of your pull request title. This will have GitHub mark it as a pull request that should not be merged yet.
+
+Test

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+
+Rules for committing changes to the respository:
+
+   1. NEVER commit directly to the master branch. Always create a new branch upon commit and create a pull request. This allows us to tag all changes made to the directly and more easily track and control where things are going in and out.
+   2. DO NOT change other people's lines or code without asking them directly.
+   3. DO NOT change province attributes without changing Guardians of Azeroth\map\provinceDef.xls. This is because the next map generation will clear all of your changes. For more information, visit this link: https://forum.paradoxplaza.com/forum/index.php?threads/tutorial-tool-how-to-fill-a-custom-map.697082/
+   4. DO NOT make character attributes higher than 30 (40 maximum). Having a higher value than this breaks certain vanilla events.
+
+General Repository Information:
+
+   1. If your pull request is currently a work in progress and requires more commits before review/finalization, please write in "(WIP)" at the end of your pull request title. This will have GitHub mark it as a pull request that should not be merged yet.
+


### PR DESCRIPTION
Preliminary information for developer instructions pulled from the root README in SVN.