### PR TITLE
WoW Guild Tabard CoA Patterns

### DIFF
--- a/interface/coat_of_arms/coats_of_arms.txt
+++ b/interface/coat_of_arms/coats_of_arms.txt
@@ -156,6 +156,13 @@ culture = {
 			color = 3
 			emblem = no
 		}
+		texture = {
+			file = "gfx\coats_of_arms\guild_pattern.tga"
+			size = { x = 16 y = 13 }
+			noOfFrames = 196
+			color = 3
+			emblem = no
+		}
 		# WHEN ADDING NEW, ALWAYS ADD AT THE END !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!11111
 	}
 }
@@ -276,7 +283,6 @@ culture = {
 			color = 3
 			emblem = no
 		}
-
 		texture = {
 			file = "gfx\\coats_of_arms\\dynasties_tauren2.tga"
 			size = { x = 9 y = 1 }
@@ -293,6 +299,14 @@ culture = {
 			emblem = no
 			random = no # Do not use for random CoAs
 		}
+		texture = {
+			file = "gfx\coats_of_arms\guild_pattern.tga"
+			size = { x = 16 y = 13 }
+			noOfFrames = 196
+			color = 3
+			emblem = no
+		}
+		# WHEN ADDING NEW, ALWAYS ADD AT THE END !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!11111
 	}
 }
 
@@ -363,6 +377,7 @@ culture = {
 			color = 0
 			random = no # Do not use for random CoAs
 		}
+		# WHEN ADDING NEW, ALWAYS ADD AT THE END !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!11111
 	}
 }
 
@@ -441,6 +456,7 @@ culture = {
 			color = 0
 			random = no # Do not use for random CoAs
 		}
+		# WHEN ADDING NEW, ALWAYS ADD AT THE END !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!11111
 	}
 }
 
@@ -510,5 +526,6 @@ culture = {
 			color = 3
 			emblem = no
 		}
+		# WHEN ADDING NEW, ALWAYS ADD AT THE END !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!11111
 	}
 }

--- a/interface/coat_of_arms/coats_of_arms.txt
+++ b/interface/coat_of_arms/coats_of_arms.txt
@@ -39,7 +39,7 @@ culture = {
 		{ 20 20 20 }	#5   	Sable (Black)
 		{ 129 24 164 }	#6   	Purple
 		{ 113 0 0 }		#7   	Sanguine (Blood Red)
-		{ 205 87 10 }	#8   	Tenné (Tawny aka orange)
+		{ 205 87 10 }	#8   	TennÃ© (Tawny aka orange)
 		{ 133 194 226 }	#9		Bleu-Celeste (Sky Blue)
 		{ 128 0 40 }	#10  	Murrey (Mulberry) Burgundy
 		{ 17 53 13 }	#11  	Dark green
@@ -159,7 +159,7 @@ culture = {
 		texture = {
 			file = "gfx\coats_of_arms\guild_pattern.tga"
 			size = { x = 16 y = 13 }
-			noOfFrames = 196
+			noOfFrames = 197
 			color = 3
 			emblem = no
 		}
@@ -302,7 +302,7 @@ culture = {
 		texture = {
 			file = "gfx\coats_of_arms\guild_pattern.tga"
 			size = { x = 16 y = 13 }
-			noOfFrames = 196
+			noOfFrames = 197
 			color = 3
 			emblem = no
 		}
@@ -476,7 +476,7 @@ culture = {
 		{ 20 20 20 }	#5   	Sable (Black)
 		{ 129 24 164 }	#6   	Purple
 		{ 113 0 0 }		#7   	Sanguine (Blood Red)
-		{ 205 87 10 }	#8   	Tenné (Tawny aka orange)
+		{ 205 87 10 }	#8   	TennÃ© (Tawny aka orange)
 		{ 133 194 226 }	#9		Bleu-Celeste (Sky Blue)
 		{ 128 0 40 }	#10  	Murrey (Mulberry) Burgundy
 		{ 17 53 13 }	#11  	Dark green


### PR DESCRIPTION
Made guild emblems from wow into CoA patterns.
_Some of these may already be patterns, which I can remove the duplicates._

**Code to be used for the coats_of_arm.txt file:**
```
texture = {
			file = "gfx\coats_of_arms\guild_pattern.tga"
			size = { x = 16 y = 13 }
			noOfFrames = 196
			color = 3
			emblem = no
		}
``` 
Would need to be added to religions.
Fits in all CoA shields.

![alt text](https://files.catbox.moe/b3gt2n.png "guild_patterns")