### PR TITLE
Zuzu's Rebalance

### DIFF
--- a/common/bloodlines/wc_bloodlines.txt
+++ b/common/bloodlines/wc_bloodlines.txt
@@ -1,9 +1,5 @@
 thoradin = {
-	diplomacy = 2
-	martial = 3
-	combat_rating = 5
-	
-	monthly_character_prestige = 0.2
+	monthly_character_prestige = 0.1
 	
 	high_elf_group_opinion = 10
 	human_group_opinion = 10
@@ -14,13 +10,9 @@ thoradin = {
 	flags = { historical_bloodline bloodline_heroes }
 }
 cenarius = {
-	learning = 2
-	martial = 3
-	combat_rating = 10
+	monthly_character_prestige = 0.1
 	
-	monthly_character_prestige = 0.2
-	
-	druidism_group_opinion = 15
+	druidism_group_opinion = 10
 	loa_group_opinion = 5
 
 	inheritance = patrilineal
@@ -29,14 +21,12 @@ cenarius = {
 	flags = { historical_bloodline bloodline_heroes }
 }
 deathwing = {
-	martial = 5
-	combat_rating = 15
+	combat_rating = 10
 	
-	monthly_character_prestige = 0.5
+	monthly_character_prestige = 0.1
 	
+	general_opinion = -10
 	void_group_opinion = 20
-	druidism_group_opinion = -15
-	dragon_religion_group_opinion = -10
 
 	inheritance = patrilineal
 	allow_bastards = no

--- a/common/buildings/wc_uniques.txt
+++ b/common/buildings/wc_uniques.txt
@@ -1,8 +1,5 @@
-
-temple = { 
-
-### SUNWELLS ###
-
+temple = {
+	### SUNWELLS ###
 	tp_sunwell = {
 		desc = tp_sunwell_desc
 		trigger = { always = yes }
@@ -24,21 +21,23 @@ temple = {
 				liege = { religion_group = arcane_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		casters = 200
 		casters_offensive = 0.5
 		casters_defensive = 0.5
-		liege_piety = 2.5
-		liege_prestige = 5
-		fort_level = 2
 		garrison_size = 1
+		fort_level = 2
+
 		ai_creation_factor = 100
-		extra_tech_building_start = -10
 	}
 	tp_sunwellcorrupted = {
 		desc = tp_sunwellcorrupted_desc
-		trigger = { always = yes }
 		potential = {
 			FROMFROM = {
 				title = b_sunwell
@@ -57,18 +56,21 @@ temple = {
 				liege = { religion_group = necromancy_group }
 			}
 		}
+
 		gold_cost = 1
-		build_time = 200
-		fort_level = -1
+		build_time = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		scourgehorde = 500
+		death_knights = 200
 		casters_offensive = -0.5
 		death_knights_offensive = 0.3
-		death_knights = 200
 		garrison_size = -0.5
-		liege_prestige = 5
-		liege_piety = 2.5
+		fort_level = -1
+
 		ai_creation_factor = 100
-		extra_tech_building_start = -10
 	}
 	tp_voidwell = {
 		desc = tp_voidwell_desc
@@ -90,15 +92,13 @@ temple = {
 				liege = { religion_group = void_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
-		# casters = 200
-		# casters_offensive = 0.5
-		# casters_defensive = 0.5
-		# liege_piety = 2.5
-		# liege_prestige = 5
-		# fort_level = 2
-		# garrison_size = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		ai_creation_factor = 100
 	}
 	tp_felwell = {
@@ -121,15 +121,13 @@ temple = {
 				liege = { religion_group = fel_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
-		# casters = 200
-		# casters_offensive = 0.5
-		# casters_defensive = 0.5
-		# liege_piety = 2.5
-		# liege_prestige = 5
-		# fort_level = 2
-		# garrison_size = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		ai_creation_factor = 100
 	}
 	tp_sunwell_light = {
@@ -152,20 +150,17 @@ temple = {
 				liege = { religion_group = light_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
-		# casters = 200
-		# casters_offensive = 0.5
-		# casters_defensive = 0.5
-		# liege_piety = 3
-		# liege_prestige = 5
-		# fort_level = 2
-		# garrison_size = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		ai_creation_factor = 100
 	}
 
-### WORLDTREES ###
-
+	### WORLD TREES ###
 	tp_worldtree = {
 		desc = tp_worldtree_desc
 		trigger = { always = yes }
@@ -184,15 +179,19 @@ temple = {
 				liege = { religion_group = druidism_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		ancients = 50
 		ancients_offensive = 0.5
 		ancients_defensive = 0.5
-		liege_piety = 2.5
-		liege_prestige = 5
-		fort_level = 2
 		garrison_size = 1
+		fort_level = 2
+
 		ai_creation_factor = 100
 	}
 	tp_felworldtree = {
@@ -212,15 +211,13 @@ temple = {
 				liege = { religion_group = fel_group }
 			}
 		}
+
 		gold_cost = 1
 		build_time = 1
-		# casters = 200
-		# casters_offensive = 0.5
-		# casters_defensive = 0.5
-		# liege_piety = 2.5
-		# liege_prestige = 5
-		# fort_level = 2
-		# garrison_size = 1
+
+		liege_prestige = 1
+		liege_piety = 0.5
+
 		ai_creation_factor = 100
 	}
 }
@@ -228,73 +225,79 @@ temple = {
 castle = {
 	ca_vault_of_archavon = {
 		desc = ca_vault_of_archavon_desc
-		potential = {
-					FROMFROM = {
-						title = b_wintergrasp
-						}
-		}
-		build_time = 1
 		trigger = { always = yes }
-		prestige_cost = 0
-		liege_prestige = 0.2
-		fort_level = 2.5
+		potential = {
+			FROMFROM = {
+				title = b_wintergrasp
+			}
+		}
+
+		gold_cost = 1
+		build_time = 1
+
 		tax_income = 1
+		liege_prestige = 0.2
+
 		levy_size = 0.1
+		fort_level = 2.5
+
 		ai_creation_factor = 100
-		extra_tech_building_start = 0
 	}
 	ca_eye_of_eternity = {
 		desc = ca_eye_of_eternity_desc
-		potential = {
-					FROMFROM = {
-						title = b_nexus
-						}
-		}
-		build_time = 1
 		trigger = { always = yes }
-		prestige_cost = 0
+		potential = {
+			FROMFROM = {
+				title = b_nexus
+			}
+		}
+
+		gold_cost = 1
+		build_time = 1
+
 		liege_prestige = 0.25
-		fort_level = 1.5
+
 		levy_size = 0.1
 		casters = 25
 		casters_offensive = 0.25
 		casters_defensive = 0.25
+		fort_level = 1.5
+
 		ai_creation_factor = 100
-		extra_tech_building_start = 0
 	}
-	
+
 	# Commented for future use - your Zuzu
 	# ca_frozenthrone = {
 		# desc = ca_frozenthrone_desc
 		# potential = {
-					# culture_group = undead_group
-					# FROMFROM = {
-						# title = b_icecrown
-					# }
-		# }
+			# culture_group = undead_group
+			# FROMFROM = {
+				# title = b_icecrown
+				# }
+			# }
 		# trigger = { always = yes }
 		# gold_cost = 1
 		# build_time = 1
-		
+
 		# scourgehorde = 2500
 		# fort_level = 2
 		# elite_infantry = 100
 		# liege_piety = 5
 		# liege_prestige = 2
-	# }
+		# }
 	# ca_icecrowncitadel = {
 		# desc = ca_icecrowncitadel_desc
 		# potential = {
 			# culture_group = undead_group
 			# FROMFROM = {
 				# title = b_icecrown
+				# }
 			# }
-		# }
 		# trigger = { TECH_CASTLE_CONSTRUCTION = 6}
-		
+
 		# gold_cost = 3000
 		# build_time = 1500
-		
+
 		# scourgehorde = 7500
 		# fort_level = 5
 		# golems = 15
@@ -302,72 +305,91 @@ castle = {
 		# elite_infantry = 250
 		# liege_piety = 5
 		# liege_prestige = 10
-		
+
 		# upgrades_from = ca_frozenthrone
-	# }
-	
+		# }
+
 	ca_old_god_1 = {
 		desc = ca_old_god_1_desc
+		trigger = { always = yes }
 		potential = {
 			FROMFROM = { has_building = ca_old_god_1 }
 		}
-		trigger = { always = yes }
+		is_active_trigger = {
+			FROM = {
+				religion = old_gods_worship
+				liege = { religion = old_gods_worship }
+			}
+		}
+
 		gold_cost = 1
 		build_time = 1
-		
+
+		tax_income = 120
+		liege_prestige = 1
+		liege_piety = 0.5
+
+		levy_reinforce_rate = 1
 		light_infantry = 2800
 		heavy_infantry = 1700
 		casters = 500
-		fort_level = 10
 		garrison_size = 1
-		levy_reinforce_rate = 1
-		
-		tax_income = 120
-		
-		liege_piety = 5
-		liege_prestige = 5
+		fort_level = 10
+
+		ai_creation_factor = 100
 	}
 	ca_old_god_2 = {
 		desc = ca_old_god_1_desc
+		trigger = { always = yes }
 		potential = {
 			FROMFROM = { has_building = ca_old_god_2 }
 		}
-		trigger = { always = yes }
+		is_active_trigger = {
+			FROM = {
+				religion = old_gods_worship
+				liege = { religion = old_gods_worship }
+			}
+		}
+
 		gold_cost = 1
 		build_time = 1
-		
+
+		tax_income = 240
+		liege_prestige = 2
+		liege_piety = 1
+
+		levy_reinforce_rate = 2
 		light_infantry = 5600
 		heavy_infantry = 3400
 		casters = 1000
-		fort_level = 20
 		garrison_size = 2
-		levy_reinforce_rate = 2
-		
-		tax_income = 240
-		
-		liege_piety = 5
-		liege_prestige = 5
+		fort_level = 20
+
+		ai_creation_factor = 100
 	}
-	
-	
-wc_dwarf_armory5 = {
-	desc = wc_dwarf_armory5_desc
-	potential = { 
-			culture_group = dwarf_group 
+
+
+	wc_dwarf_armory5 = {
+		desc = wc_dwarf_armory5_desc
+		trigger = { always = yes }
+		potential = {
+			culture_group = dwarf_group
 			FROMFROM = { title = b_great_forge }
+		}
+		
+
+		gold_cost = 1250
+		build_time = 1250
+
+		liege_prestige = 0.5
+
+		levy_reinforce_rate = 1
+		land_morale = 0.2
+		
+		military_techpoints = 0.25
+
+		# upgrades_from = wc_dwarf_armory4
+
+		ai_creation_factor = 100
 	}
-	trigger = { always = yes }
-	
-	gold_cost = 1250
-	build_time = 1250
-	
-	morale = 0.2
-	levy_reinforce_rate = 1
-	military_techpoints = 0.25
-	liege_prestige = 0.5
-	
-	# upgrades_from = wc_dwarf_armory4
-	}
-	
-	
 }

--- a/common/traits/wc_race_traits.txt
+++ b/common/traits/wc_race_traits.txt
@@ -163,7 +163,7 @@ creature_high_elf = {
 	same_opinion = 10
 	general_opinion = -5
 
-	learning = 3
+	learning = 2
 	fertility = -0.4
 	health = 2
 
@@ -259,10 +259,10 @@ creature_red_wyrm = {
 	general_opinion = -5
 	dynasty_opinion = 10
 
-	diplomacy = 4
+	diplomacy = 2
 	martial = 1
 	stewardship = 2
-	learning = 3
+	learning = 2
 	fertility = 1
 	health = 3
 	combat_rating = 100
@@ -294,7 +294,7 @@ creature_blue_drake = {
 	dynasty_opinion = 10
 
 	stewardship = 1
-	learning = 3
+	learning = 2
 	fertility = -10
 	health = 1
 	combat_rating = 30
@@ -312,7 +312,7 @@ creature_blue_dragon = {
 
 	martial = 1
 	stewardship = 1
-	learning = 4
+	learning = 2
 
 	combat_rating = 60
 	health = 2
@@ -330,8 +330,8 @@ creature_blue_wyrm = {
 
 	diplomacy = 1
 	martial = 1
-	stewardship = 3
-	learning = 5
+	stewardship = 2
+	learning = 3
 	fertility = 1
 	health = 3
 	combat_rating = 100
@@ -383,7 +383,7 @@ creature_green_dragon = {
 	diplomacy = 1
 	stewardship = 1
 	intrigue = 1
-	learning = 3
+	learning = 2
 
 	combat_rating = 60
 	health = 2
@@ -399,10 +399,10 @@ creature_green_wyrm = {
 	general_opinion = -5
 	dynasty_opinion = 10
 
-	diplomacy = 3
+	diplomacy = 2
 	stewardship = 2
 	intrigue = 1
-	learning = 4
+	learning = 2
 	fertility = 1
 	health = 3
 	combat_rating = 100
@@ -450,7 +450,7 @@ creature_black_dragon = {
 	general_opinion = -5
 	dynasty_opinion = 10
 
-	martial = 4
+	martial = 2
 	intrigue = 2
 
 	combat_rating = 60
@@ -467,9 +467,9 @@ creature_black_wyrm = {
 	general_opinion = -5
 	dynasty_opinion = 10
 
-	martial = 5
+	martial = 3
 	stewardship = 1
-	intrigue = 3
+	intrigue = 2
 	learning = 1
 	fertility = 1
 	health = 3
@@ -486,7 +486,7 @@ creature_goblin = {		# 4
 	same_opinion = 10
 	general_opinion = -5
 
-	stewardship = 4
+	stewardship = 2
 	intrigue = 1
 	learning = 1
 
@@ -533,7 +533,7 @@ creature_draenei = {
 	same_opinion = 10
 	general_opinion = -5
 
-	diplomacy = 3
+	diplomacy = 2
 	martial = -1
 	intrigue = -2
 	learning = 2
@@ -627,7 +627,7 @@ creature_abomination = {
 creature_lich = {
 	stewardship = 1		# 6
 	intrigue = 1
-	learning = 4
+	learning = 2
 
 	combat_rating = 40
 	health = 0.8
@@ -643,8 +643,8 @@ creature_annihilan = {
 	general_opinion = -5
 
 	diplomacy = -8
-	martial = 7
-	stewardship = 3
+	martial = 4
+	stewardship = 2
 	intrigue = -2
 	learning = 2
 	fertility = -10
@@ -662,7 +662,7 @@ creature_nathrezim = {
 
 	diplomacy = -1
 	martial = -2
-	intrigue = 5
+	intrigue = 3
 	learning = 2
 	fertility = -10
 	health = 3
@@ -681,7 +681,7 @@ creature_eredruin = {
 	general_opinion = -5
 
 	diplomacy = -2
-	martial = 4
+	martial = 2
 	intrigue = -2
 	learning = -2
 	fertility = -10
@@ -749,9 +749,9 @@ creature_eredar = {
 	general_opinion = -5
 
 	diplomacy = -3
-	martial = 3
-	intrigue = 4
-	learning = 6
+	martial = 2
+	intrigue = 2
+	learning = 3
 	fertility = -10
 	health = 3
 	combat_rating = 25
@@ -766,7 +766,7 @@ creature_sayaadi = {
 	general_opinion = -5
 
 	diplomacy = -1
-	intrigue = 3
+	intrigue = 2
 	fertility = -10
 	health = 2
 	combat_rating = 10
@@ -816,7 +816,7 @@ creature_observer = {
 	martial = -2
 	stewardship = -2
 	intrigue = 2
-	learning = 6
+	learning = 3
 	fertility = -10
 	health = 2
 	combat_rating = 30
@@ -828,10 +828,10 @@ creature_observer = {
 }
 creature_avatar_of_sargeras = {
 	diplomacy = -6
-	martial = 6
+	martial = 3
 	stewardship = 2
-	intrigue = 6
-	learning = 4
+	intrigue = 3
+	learning = 2
 	fertility = -10
 	health = 4
 	combat_rating = 150
@@ -898,7 +898,7 @@ creature_fire_elemental = {
 	general_opinion = -10
 
 	diplomacy = -1
-	martial = 3
+	martial = 2
 	stewardship = -1
 	intrigue = -1
 	fertility = -10
@@ -921,7 +921,7 @@ creature_flamewaker = {
 	general_opinion = -10
 
 	diplomacy = -1
-	martial = 3
+	martial = 2
 	stewardship = -1
 	intrigue = -1
 	fertility = -10
@@ -1070,7 +1070,7 @@ creature_watcher = {
 	general_opinion = -5
 
 	martial = 2
-	stewardship = 4
+	stewardship = 2
 	intrigue = -2
 	fertility = -10
 	health = 4
@@ -1125,7 +1125,7 @@ creature_kvaldir = {
 
 	diplomacy = -1
 	stewardship = -1
-	martial = 3
+	martial = 2
 	intrigue = 1
 	fertility = -10
 	health = 3
@@ -1175,7 +1175,7 @@ creature_mechagnome = {
 	general_opinion = -5
 
 	stewardship = 2
-	learning = 4
+	learning = 2
 	fertility = -10
 	health = 3
 	
@@ -1236,7 +1236,7 @@ creature_bronze_dragon = {
 	dynasty_opinion = 10
 
 	martial = 1
-	stewardship = 3
+	stewardship = 2
 	learning = 2
 
 	fertility = -10
@@ -1253,7 +1253,7 @@ creature_bronze_wyrm = {
 	dynasty_opinion = 10
 
 	martial = 2
-	stewardship = 5
+	stewardship = 3
 	intrigue = 1
 	learning = 2
 	fertility = 1
@@ -1428,7 +1428,7 @@ creature_dryad = {
 
 	diplomacy = 1
 	martial = 2
-	learning = 3
+	learning = 2
 	fertility = -0.4
 	health = 3
 	combat_rating = 10
@@ -1445,7 +1445,7 @@ creature_frostnymph = {		# 4
 	druidism_group_opinion = 10
 
 	diplomacy = 1
-	martial = 3
+	martial = 2
 	learning = 2
 	fertility = -0.4
 	health = 3
@@ -1464,7 +1464,7 @@ creature_highborne = {		# 4
 	# high_elf_group_opinion = 10
 
 	stewardship = 1
-	learning = 3
+	learning = 2
 	fertility = -0.4
 	health = 2
 	
@@ -1497,7 +1497,7 @@ creature_infinite_drake = {
 	diplomacy= -1
 	martial = 1
 	stewardship = 2
-	learning = 3
+	learning = 2
 	fertility = -10
 	health = 1
 	combat_rating = 30
@@ -1517,7 +1517,7 @@ creature_infinite_dragon = {
 	martial = 2
 	stewardship = 2
 	intrigue = 2
-	learning = 4
+	learning = 2
 	fertility = -10
 	health = 2
 	combat_rating = 60
@@ -1533,10 +1533,10 @@ creature_infinite_wyrm = {
 
 	# 76
 	diplomacy= -3
-	martial = 3
-	stewardship = 3
-	intrigue = 3
-	learning = 4
+	martial = 2
+	stewardship = 2
+	intrigue = 2
+	learning = 2
 	fertility = 1
 	health = 3
 	combat_rating = 100
@@ -1587,7 +1587,7 @@ creature_sethrak = {		# 4
 
 
 	stewardship = 1
-	martial = 3
+	martial = 2
 
 
 	health = 0.2
@@ -1627,7 +1627,7 @@ creature_protector = {
 	druidism_group_opinion = 30
 
 	diplomacy = -10
-	martial = 5
+	martial = 3
 	fertility = -10
 	health = 10
 	combat_rating = 40
@@ -1644,7 +1644,7 @@ creature_ancient_war = {
 	druidism_group_opinion = 30
 
 	diplomacy = -10
-	martial = 10
+	martial = 5
 	fertility = -10
 	health = 10
 	combat_rating = 60
@@ -1660,7 +1660,7 @@ creature_ancient_lore = {
 	druidism_group_opinion = 30
 
 	diplomacy = -5
-	learning = 10
+	learning = 5
 	fertility = -10
 	health = 10
 	combat_rating = 60
@@ -1676,8 +1676,8 @@ creature_ancient_wind = {
 	druidism_group_opinion = 30
 
 	diplomacy = -10
-	martial = 5
-	learning = 5
+	martial = 3
+	learning = 3
 	fertility = -10
 	health = 10
 	combat_rating = 60

--- a/common/traits/wc_race_traits.txt
+++ b/common/traits/wc_race_traits.txt
@@ -642,7 +642,7 @@ creature_annihilan = {
 	same_opinion = 10
 	general_opinion = -5
 
-	diplomacy = -8
+	diplomacy = -4
 	martial = 4
 	stewardship = 2
 	intrigue = -2
@@ -748,7 +748,7 @@ creature_eredar = {
 	opposite_opinion = -50
 	general_opinion = -5
 
-	diplomacy = -3
+	diplomacy = -2
 	martial = 2
 	intrigue = 2
 	learning = 3
@@ -827,7 +827,7 @@ creature_observer = {
 	customizer = no
 }
 creature_avatar_of_sargeras = {
-	diplomacy = -6
+	diplomacy = -3
 	martial = 3
 	stewardship = 2
 	intrigue = 3
@@ -1138,7 +1138,7 @@ creature_kvaldir = {
 }
 creature_nerubian = {
 	# 2
-	diplomacy = -3
+	diplomacy = -2
 	stewardship = 2
 	intrigue = -1
 	learning = 2
@@ -1287,7 +1287,7 @@ creature_nraqi = {
 	same_opinion = 10
 	general_opinion = -5
 
-	diplomacy = -5
+	diplomacy = -3
 	martial = 2
 	intrigue = 2
 	fertility = -10
@@ -1303,7 +1303,7 @@ creature_cthraxxi = {
 	same_opinion = 10
 	general_opinion = -5
 
-	diplomacy = -5
+	diplomacy = -3
 	martial = 2
 	intrigue = 2
 	learning = 1
@@ -1626,7 +1626,7 @@ creature_protector = {
 	same_opinion = 30
 	druidism_group_opinion = 30
 
-	diplomacy = -10
+	diplomacy = -5
 	martial = 3
 	fertility = -10
 	health = 10
@@ -1643,7 +1643,7 @@ creature_ancient_war = {
 	same_opinion = 30
 	druidism_group_opinion = 30
 
-	diplomacy = -10
+	diplomacy = -5
 	martial = 5
 	fertility = -10
 	health = 10
@@ -1659,7 +1659,7 @@ creature_ancient_lore = {
 	same_opinion = 30
 	druidism_group_opinion = 30
 
-	diplomacy = -5
+	diplomacy = -3
 	learning = 5
 	fertility = -10
 	health = 10
@@ -1675,7 +1675,7 @@ creature_ancient_wind = {
 	same_opinion = 30
 	druidism_group_opinion = 30
 
-	diplomacy = -10
+	diplomacy = -5
 	martial = 3
 	learning = 3
 	fertility = -10

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -258,7 +258,7 @@
 	# dna="0dffg0ha0a0"
 	# properties="kd0a0k00000000"
 	# culture=shattered_hand religion=orcish_fel
-	# martial=9 diplomacy=7 stewardship=7 intrigue=5 learning=4
+	# martial=6 diplomacy=7 stewardship=7 intrigue=5 learning=4
 	# dynasty=2100
 	# add_trait=brilliant_strategist add_trait=cruel
 	# add_trait=diligent add_trait=wroth add_trait=ambitious add_trait=one_handed

--- a/history/characters/11000_dark_iron.txt
+++ b/history/characters/11000_dark_iron.txt
@@ -1247,7 +1247,7 @@
 	dynasty=4010
 	dna="fchlojjmgof"
 	culture=dark_iron religion=holy_light
-	martial=8 diplomacy=5 stewardship=6 intrigue=4 learning=10
+	martial=8 diplomacy=5 stewardship=6 intrigue=4 learning=6
 	father = 12052
 	trait=scholarly_theologian trait=trusting trait=stubborn trait=patient trait=content trait=honest
 	trait = creature_dwarf

--- a/history/characters/16000_gnome.txt
+++ b/history/characters/16000_gnome.txt
@@ -1323,7 +1323,7 @@
 	dynasty=10110
 	dna="cabmingokoa"
 	culture=mechagnome religion=mystery_of_the_makers
-	martial=1 diplomacy=3 stewardship=12 intrigue=1 learning=14
+	martial=1 diplomacy=3 stewardship=7 intrigue=1 learning=7
 	add_trait=scholarly_theologian add_trait=genius add_trait=content
 	disallow_random_traits = yes
 	2.11.12={ birth=yes add_trait=creature_mechagnome immortal_age=18 }

--- a/history/characters/180000_magnataur.txt
+++ b/history/characters/180000_magnataur.txt
@@ -964,7 +964,7 @@
 	dynasty=114000
 	dna="lhgfloiopnm"
 	culture=magnataur religion=primitive_shamanism
-	martial=10 diplomacy=9 stewardship=8 intrigue=5 learning=1
+	martial=6 diplomacy=5 stewardship=5 intrigue=5 learning=1
 	add_trait=skilled_tactician
 	add_trait=proud add_trait=strong add_trait=wroth add_trait=ambitious
 	disallow_random_traits = yes
@@ -2012,7 +2012,7 @@
 	dynasty=114003
 	dna="fcnlnnlmaae"
 	culture=magnataur religion=primitive_shamanism
-	martial=7 diplomacy=14 stewardship=5 intrigue=4 learning=18
+	martial=7 diplomacy=6 stewardship=5 intrigue=4 learning=5
 	add_trait=charismatic_negotiator add_trait=content add_trait=humble add_trait=gluttonous add_trait=patient 
 	add_trait=stressed add_trait=slow 
 	father=180273	#Bhirngreig
@@ -5403,7 +5403,7 @@
 	dynasty=114005
 	dna="odbgfmkeejl"
 	culture=magnataur religion=primitive_shamanism
-	martial=14 diplomacy=7 stewardship=7 intrigue=18 learning=6
+	martial=5 diplomacy=7 stewardship=7 intrigue=5 learning=6
 	add_trait=detached_priest add_trait=poet add_trait=cruel add_trait=patient add_trait=cynical 
 	add_trait=gregarious 
 	father=180776	#Filkellgarr
@@ -6504,7 +6504,7 @@
 	dynasty=114007
 	dna="ijmnlobijco"
 	culture=magnataur religion=primitive_shamanism
-	martial=12 diplomacy=7 stewardship=4 intrigue=12 learning=8
+	martial=5 diplomacy=7 stewardship=4 intrigue=7 learning=8
 	add_trait=skilled_tactician add_trait=lustful add_trait=gluttonous add_trait=gregarious 
 	add_trait=envious add_trait=cruel
 	father=180922	
@@ -8557,7 +8557,7 @@
 	dynasty=114008
 	dna="pjlocjpphdc"
 	culture=magnataur religion=primitive_shamanism
-	martial=17 diplomacy=4 stewardship=4 intrigue=12 learning=5
+	martial=6 diplomacy=4 stewardship=4 intrigue=7 learning=5
 	add_trait=strong add_trait=arbitrary add_trait=cruel add_trait=wroth add_trait=stressed 
 	father=181260	#Gortok
 	565.5.24={ birth=yes }

--- a/history/characters/190000_taunka.txt
+++ b/history/characters/190000_taunka.txt
@@ -772,7 +772,7 @@
 	dynasty=115000
 	dna="cmlakhpjgbf"
 	culture=taunka religion=shamanism
-	martial=7 diplomacy=12 stewardship=5 intrigue=4 learning=9
+	martial=7 diplomacy=5 stewardship=5 intrigue=4 learning=9
 	add_trait=charismatic_negotiator add_trait=temperate add_trait=honest add_trait=gregarious 
 	add_trait=class_shaman_3
 	father=190062	#Dezrel'l't
@@ -3017,7 +3017,7 @@
 	dynasty=115003
 	dna="omibekpibdk"
 	culture=taunka religion=shamanism
-	martial=9 diplomacy=8 stewardship=12 intrigue=7 learning=8
+	martial=6 diplomacy=8 stewardship=7 intrigue=7 learning=8
 	add_trait=grey_eminence add_trait=honest add_trait=craven add_trait=diligent add_trait=class_shaman_2 
 	father=190361	#Kualen
 	552.10.20={ birth=yes }
@@ -3936,7 +3936,7 @@
 	dynasty=115004
 	dna="biclaenofke"
 	culture=taunka religion=shamanism
-	martial=14 diplomacy=11 stewardship=10 intrigue=6 learning=6
+	martial=6 diplomacy=5 stewardship=6 intrigue=6 learning=6
 	add_trait=skilled_tactician add_trait=strong add_trait=temperate add_trait=honest add_trait=just 
 	father=190474	#Hulnalum
 	553.7.3={ birth=yes }
@@ -4874,7 +4874,7 @@
 	dynasty=115005
 	dna="bdpgienajfn"
 	culture=taunka religion=shamanism
-	martial=15 diplomacy=13 stewardship=5 intrigue=9 learning=7
+	martial=6 diplomacy=6 stewardship=5 intrigue=6 learning=7
 	add_trait=grey_eminence add_trait=zealous add_trait=kind add_trait=trusting add_trait=gregarious add_trait=class_shaman_5
 	father=190575	#Huldomo
 	538.10.21={ birth=yes }

--- a/history/characters/1_azerothian.txt
+++ b/history/characters/1_azerothian.txt
@@ -5,7 +5,7 @@
 	religion=holy_light culture=azerothian
 	dna="ahfga0abac0"
 	properties="an0bbb00000000"
-	martial=8 diplomacy=6 intrigue=7 stewardship=9 learning=4
+	martial=8 diplomacy=6 intrigue=7 stewardship=6 learning=4
 	give_nickname = nick_the_adamant
 	add_trait=skilled_tactician add_trait=brave add_trait=trusting
 	father=7
@@ -12168,7 +12168,7 @@
 	name=Gavinrad
 	dna="0g0gd000aa0"
 	culture=azerothian religion=holy_light
-	martial=8 diplomacy=10 stewardship=7 intrigue=2 learning=7
+	martial=8 diplomacy=7 stewardship=7 intrigue=2 learning=7
 	add_trait=brilliant_strategist add_trait=kind add_trait=charitable add_trait=trusting add_trait=honest  
 	539.6.9={ birth=yes add_trait=creature_human }
 	557.8.10={
@@ -12259,7 +12259,7 @@
 5806={
 	name=Moroes
 	culture=azerothian religion=holy_light
-	martial=4 diplomacy=8 stewardship=9 intrigue=8 learning=4
+	martial=4 diplomacy=8 stewardship=6 intrigue=8 learning=4
 	add_trait=midas_touched
 	add_trait=diligent
 	add_trait=honest

--- a/history/characters/200000_farraki.txt
+++ b/history/characters/200000_farraki.txt
@@ -1127,7 +1127,7 @@
 	dynasty=8384
 	dna="gephlbengif"
 	culture=farraki religion=cult_of_loa
-	martial=11 diplomacy=9 stewardship=13 intrigue=12 learning=5
+	martial=6 diplomacy=7 stewardship=7 intrigue=7 learning=5
 	add_trait=skilled_tactician add_trait=ambitious add_trait=zealous add_trait=wroth add_trait=cruel add_trait=class_warrior_7 add_trait=aggressive_leader add_trait=proud
 	father=200100	#Vuze
 	586.8.24={ birth=yes }

--- a/history/characters/210000_tauren.txt
+++ b/history/characters/210000_tauren.txt
@@ -260,7 +260,7 @@
 	dynasty=1160014
 	dna="gopnbfngajl"
 	culture=tauren religion=earth_mother_worship
-	martial=4 diplomacy=5 stewardship=6 intrigue=2 learning=10
+	martial=4 diplomacy=5 stewardship=6 intrigue=2 learning=6
 	add_trait=martial_cleric add_trait=gregarious add_trait=kind add_trait=scholar add_trait=diligent 
 	disallow_random_traits = yes
 	father=2100823 #Huldomo

--- a/history/characters/220000_dark_troll.txt
+++ b/history/characters/220000_dark_troll.txt
@@ -1010,7 +1010,7 @@
 	dynasty=8385
 	dna="jclodhodfcb"
 	culture=dark_troll religion=cult_of_loa
-	martial=6 diplomacy=7 stewardship=5 intrigue=12 learning=14
+	martial=6 diplomacy=7 stewardship=5 intrigue=7 learning=7
 	add_trait=scholarly_theologian add_trait=chaste add_trait=class_loa_priest_5 add_trait=gregarious 
 	father=220085	#Urbin
 	575.1.26={ birth=yes }

--- a/history/characters/22000_wildhammer.txt
+++ b/history/characters/22000_wildhammer.txt
@@ -20,7 +20,7 @@
 	dynasty=4400
 	dna="pbfeahemhab"
 	culture=wildhammer religion=shamanism
-	martial=9 diplomacy=3 stewardship=6 intrigue=3 learning=6
+	martial=5 diplomacy=3 stewardship=6 intrigue=3 learning=6
 	add_trait=brilliant_strategist add_trait=honest add_trait=just add_trait=brave
 	father=22052	#Thoryl
 	disallow_random_traits = yes
@@ -35,7 +35,7 @@
 	dynasty=4400
 	dna="phpjnheghcn"
 	culture=wildhammer religion=shamanism
-	martial=10 diplomacy=5 stewardship=2 intrigue=2 learning=6
+	martial=6 diplomacy=5 stewardship=2 intrigue=2 learning=6
 	add_trait=brilliant_strategist add_trait=brave add_trait=wroth add_trait=temperate
 	father=22052	#Thoryl
 	disallow_random_traits = yes

--- a/history/characters/270000_tolvir.txt
+++ b/history/characters/270000_tolvir.txt
@@ -800,7 +800,7 @@
 	dynasty=121001
 	dna="paebbnjokkg"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=12 diplomacy=14 stewardship=8 intrigue=5 learning=8
+	martial=6 diplomacy=6 stewardship=8 intrigue=5 learning=8
 	add_trait=tough_soldier add_trait=humble add_trait=diligent add_trait=just add_trait=patient 
 	father=270070	#Ithihor
 	554.8.24={ birth=yes }
@@ -1021,7 +1021,7 @@
 	dynasty=121003
 	dna="gflaloining"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=20 diplomacy=15 stewardship=17 intrigue=14 learning=10
+	martial=7 diplomacy=6 stewardship=5 intrigue=7 learning=6
 	add_trait=grey_eminence add_trait=genius add_trait=temperate add_trait=ambitious add_trait=diligent 
 	add_trait=strong add_trait=just add_trait=proud 
 	father=270209	#Bankhiram
@@ -1295,7 +1295,7 @@
 	dynasty=121003
 	dna="dmadeimnook"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=7 diplomacy=18 stewardship=5 intrigue=6 learning=8
+	martial=7 diplomacy=6 stewardship=5 intrigue=6 learning=8
 	add_trait=skilled_tactician add_trait=just add_trait=quick add_trait=kind add_trait=honest add_trait=ill add_trait=humble add_trait=patient
 	father=270232	#Munbenhi
 	284.3.6={ birth=yes }
@@ -3002,7 +3002,7 @@
 	dynasty=121004
 	dna="nhgbjelmhmh"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=12 diplomacy=6 stewardship=4 intrigue=7 learning=16
+	martial=6 diplomacy=6 stewardship=4 intrigue=7 learning=7
 	add_trait=martial_cleric add_trait=ambitious add_trait=envious add_trait=deceitful add_trait=zealous add_trait=class_warlock_4
 	father=270676	#Chabhasoth
 	540.8.3={ birth=yes }
@@ -12374,7 +12374,7 @@
 	dynasty=121013
 	dna="afgfbibkfhp"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=10 diplomacy=8 stewardship=8 intrigue=4 learning=4
+	martial=6 diplomacy=8 stewardship=8 intrigue=4 learning=4
 	add_trait=midas_touched add_trait=envious add_trait=patient add_trait=cruel add_trait=brave 
 	father=272478	#Zurmaru
 	557.12.6={ birth=yes }
@@ -13455,7 +13455,7 @@
 	dynasty=121014
 	dna="bdjddjcbmlg"
 	culture=tolvir religion=mystery_of_the_makers
-	martial=5 diplomacy=8 stewardship=4 intrigue=6 learning=12
+	martial=5 diplomacy=8 stewardship=4 intrigue=6 learning=7
 	add_trait=martial_cleric add_trait=envious add_trait=content add_trait=deceitful add_trait=wroth add_trait=zealous add_trait=aggressive_leader add_trait=class_priest_5
 	father=272687	#Urmulet
 	550.1.14={ birth=yes }

--- a/history/characters/290000_frozen_giant.txt
+++ b/history/characters/290000_frozen_giant.txt
@@ -3,7 +3,7 @@
 	dynasty=123000
 	dna="kbojjfoifmn"
 	culture=frozen_giant religion=mystery_of_the_makers
-	martial=8 diplomacy=8 stewardship=8 intrigue=3 learning=10
+	martial=8 diplomacy=8 stewardship=8 intrigue=3 learning=6
 	add_trait=mastermind_theologian add_trait=brave add_trait=kind add_trait=just add_trait=diligent 
 	1.11.4={ birth=yes }
 	1094.12.6={ death=yes }

--- a/history/characters/29000_gnoll.txt
+++ b/history/characters/29000_gnoll.txt
@@ -1087,7 +1087,7 @@
 	name=Arguc
 	dynasty=12233
 	culture=gnoll religion=primitive_shamanism
-	martial=10
+	martial=5
 	trait = creature_gnoll
 	299.1.1={ birth=yes }
         350.4.5={

--- a/history/characters/330000_highborne.txt
+++ b/history/characters/330000_highborne.txt
@@ -4,7 +4,7 @@
 	dynasty=127000
 	dna="fiodochhocm"
 	culture=highborne religion=arcane_religion
-	martial=8 diplomacy=5 stewardship=7 intrigue=5 learning=10
+	martial=8 diplomacy=5 stewardship=7 intrigue=5 learning=6
 	add_trait=skilled_tactician add_trait=ambitious add_trait=arbitrary add_trait=proud add_trait=diligent
 	disallow_random_traits = yes
 	1.1.23={ birth=yes add_trait=creature_highborne }

--- a/history/characters/340000_night_elf.txt
+++ b/history/characters/340000_night_elf.txt
@@ -31,7 +31,7 @@
 	dynasty=128002
 	dna="kpeknlgnbef"
 	culture=night_elf religion=kaldorei_religion
-	martial=10 diplomacy=8 stewardship=8 intrigue=3 learning=8
+	martial=5 diplomacy=8 stewardship=8 intrigue=3 learning=8
 	add_trait=mastermind_theologian add_trait=diligent add_trait=chaste add_trait=just add_trait=brave add_trait=temperate
 	add_trait=fair add_trait=paranoid add_trait=zealous add_trait=wroth
 	disallow_random_traits = yes
@@ -57,7 +57,7 @@
 	dynasty=128003
 	dna="ngadgkenebb"
 	culture=night_elf religion=kaldorei_religion
-	martial=12 diplomacy=10 stewardship=10 intrigue=4 learning=10
+	martial=6 diplomacy=7 stewardship=6 intrigue=4 learning=6
 	add_trait=mastermind_theologian add_trait=robust add_trait=patient add_trait=diligent add_trait=brave add_trait=quick add_trait=chaste
 	father=340010
 	disallow_random_traits = yes
@@ -92,7 +92,7 @@
 	dynasty=128003
 	dna="dbfgpmkkkjh"
 	culture=night_elf religion=illidari
-	martial=12 diplomacy=6 stewardship=6 intrigue=8 learning=6
+	martial=6 diplomacy=6 stewardship=6 intrigue=8 learning=6
 	add_trait=elusive_shadow add_trait=wroth add_trait=quick add_trait=ambitious add_trait=diligent add_trait=robust add_trait=shrewd
 	father=340010
 	disallow_random_traits = yes
@@ -122,7 +122,7 @@
 	dynasty=128004
 	dna="fjnmfnbdjfk"
 	culture=night_elf religion=kaldorei_religion
-	martial=5 diplomacy=4 stewardship=10 intrigue=2 learning=6
+	martial=5 diplomacy=4 stewardship=6 intrigue=2 learning=6
 	add_trait=midas_touched add_trait=patient add_trait=honest add_trait=trusting add_trait=gregarious add_trait=administrator add_trait=content
 	disallow_random_traits = yes
 	1.7.13={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -281,7 +281,7 @@
 	dynasty=128012
 	dna="ijcddjglagg"
 	culture=night_elf religion=kaldorei_religion
-	martial=5 diplomacy=7 stewardship=9 intrigue=6 learning=8
+	martial=5 diplomacy=7 stewardship=6 intrigue=6 learning=8
 	add_trait=fortune_builder add_trait=brave add_trait=kind add_trait=content add_trait=gluttonous
 	disallow_random_traits = yes
 	1.10.10={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -413,7 +413,7 @@
 	dynasty=128014
 	dna="ldhnpgfkhnl"
 	culture=night_elf religion=kaldorei_religion
-	martial=5 diplomacy=7 stewardship=10 intrigue=5 learning=6
+	martial=5 diplomacy=7 stewardship=6 intrigue=5 learning=6
 	add_trait=midas_touched add_trait=brave add_trait=administrator add_trait=content add_trait=kind add_trait=paranoid
 	disallow_random_traits = yes
 	1.3.3={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -501,7 +501,7 @@
 	dynasty=128016
 	dna="fbmkepoicin"
 	culture=night_elf religion=kaldorei_religion
-	martial=4 diplomacy=5 stewardship=9 intrigue=4 learning=7
+	martial=4 diplomacy=5 stewardship=6 intrigue=4 learning=7
 	add_trait=scholarly_theologian add_trait=chaste add_trait=charitable add_trait=kind add_trait=temperate add_trait=diligent
 	disallow_random_traits = yes
 	1.10.23={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -670,7 +670,7 @@
 	female=yes
 	dna="00000000bb0"
 	culture=night_elf religion=kaldorei_religion
-	martial=5 diplomacy=9 stewardship=4 intrigue=4 learning=8
+	martial=5 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=scholarly_theologian add_trait=diligent add_trait=kind add_trait=zealous add_trait = humble
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -688,7 +688,7 @@
 	female=yes
 	dna="00000000fa0"
 	culture=night_elf religion=kaldorei_religion
-	martial=7 diplomacy=9 stewardship=4 intrigue=4 learning=8
+	martial=7 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=diligent add_trait=just add_trait=zealous add_trait = chaste
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -724,7 +724,7 @@
 	female=yes
 	dna="00000000aa0"
 	culture=night_elf religion=kaldorei_religion
-	martial=6 diplomacy=9 stewardship=6 intrigue=4 learning=8
+	martial=6 diplomacy=7 stewardship=6 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=charitable add_trait=kind add_trait=zealous add_trait = chaste
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -760,7 +760,7 @@
 	female=yes
 	dna="00000000bb0"
 	culture=night_elf religion=kaldorei_religion
-	martial=7 diplomacy=10 stewardship=4 intrigue=4 learning=8
+	martial=7 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=diligent add_trait=kind add_trait=zealous add_trait = chaste
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -778,7 +778,7 @@
 	female=yes
 	dna="00000000ca0"
 	culture=night_elf religion=kaldorei_religion
-	martial=7 diplomacy=10 stewardship=4 intrigue=4 learning=8
+	martial=7 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=humble add_trait=kind add_trait=zealous add_trait = temperate
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -798,7 +798,7 @@
 	dynasty=128024
 	dna="00000000eb0"
 	culture=night_elf religion=kaldorei_religion
-	martial=9 diplomacy=7 stewardship=4 intrigue=4 learning=8
+	martial=5 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=patient add_trait=kind add_trait=zealous add_trait = chaste
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -928,7 +928,7 @@
 	female=yes
 	dna="00000000ca0"
 	culture=night_elf religion=kaldorei_religion
-	martial=11 diplomacy=7 stewardship=4 intrigue=4 learning=8
+	martial=6 diplomacy=7 stewardship=4 intrigue=4 learning=8
 	add_trait=mastermind_theologian add_trait=humble add_trait=kind add_trait=zealous add_trait = temperate
 	disallow_random_traits = yes
 	1.10.17={ birth=yes add_trait=creature_night_elf immortal_age=18 }
@@ -948,7 +948,7 @@
 	dynasty=128029
 	dna="kmimaacnnen"
 	culture=night_elf religion=kaldorei_religion
-	martial=10 diplomacy=4 stewardship=5 intrigue=3 learning=4
+	martial=6 diplomacy=4 stewardship=5 intrigue=3 learning=4
 	add_trait=skilled_tactician add_trait=brave add_trait=stubborn add_trait=wroth add_trait=hunter add_trait=sturdy add_trait=shrewd add_trait=patient
 	disallow_random_traits = yes
 	1.1.7={ birth=yes add_trait=creature_night_elf immortal_age=18 }

--- a/history/characters/380000_frostnymph.txt
+++ b/history/characters/380000_frostnymph.txt
@@ -4,7 +4,7 @@
 	dynasty=129024
 	female=yes
 	culture=frostnymph religion=druidism_beliefs
-	martial=10 diplomacy=6 stewardship=7 intrigue=4 learning=8
+	martial=5 diplomacy=6 stewardship=7 intrigue=4 learning=8
 	add_trait=charismatic_negotiator add_trait=duelist add_trait=wroth add_trait=shy add_trait=kind
 	add_trait=charitable 
 	disallow_random_traits = yes

--- a/history/characters/390000_sethrak.txt
+++ b/history/characters/390000_sethrak.txt
@@ -4,7 +4,7 @@
 	dynasty=142000
 	dna="oaecjcpjell"
 	culture=sethrak religion=cult_of_loa
-	martial=9 diplomacy=5 stewardship=8 intrigue=5 learning=8
+	martial=5 diplomacy=5 stewardship=8 intrigue=5 learning=8
 	add_trait=skilled_tactician add_trait=cynical add_trait=deceitful add_trait=ambitious
 	add_trait=diligent add_trait=brave
 	disallow_random_traits = yes
@@ -32,7 +32,7 @@
 	dynasty=142002
 	dna="hpajcmmjchj"
 	culture=sethrak religion=cult_of_loa
-	martial=10 diplomacy=7 stewardship=7 intrigue=8 learning=8
+	martial=5 diplomacy=7 stewardship=7 intrigue=8 learning=8
 	add_trait=tough_soldier add_trait=brave add_trait=humble add_trait=zealous add_trait=diligent
 	disallow_random_traits = yes
 	3.7.25={ birth=yes add_trait=creature_sethrak }

--- a/history/characters/410000_dryad.txt
+++ b/history/characters/410000_dryad.txt
@@ -5,7 +5,7 @@
 	dynasty=128011
 	dna="gjolkohbdhb"
 	culture=dryad religion=kaldorei_religion
-	martial=5 diplomacy=4 stewardship=6 intrigue=6 learning=8
+	martial=4 diplomacy=3 stewardship=5 intrigue=4 learning=5
 	add_trait=scholarly_theologian add_trait=temperate add_trait=trusting add_trait=diligent add_trait=just
 	disallow_random_traits = yes
 	father=410002
@@ -18,7 +18,7 @@
 	dynasty=128011
 	dna="gldpaohpdnp"
 	culture=dryad religion=kaldorei_religion
-	martial=6 diplomacy=10 stewardship=6 intrigue=5 learning=10
+	martial=4 diplomacy=5 stewardship=4 intrigue=3 learning=5
 	add_trait=scholarly_theologian add_trait=kind add_trait=humble add_trait=diligent add_trait=content
 	disallow_random_traits = yes
 	father=410002
@@ -31,7 +31,7 @@
 	dynasty=128011
 	dna="ojflhdfbmgb"
 	culture=dryad religion=kaldorei_religion
-	martial=10 diplomacy=8 stewardship=5 intrigue=6 learning=12
+	martial=5 diplomacy=4 stewardship=3 intrigue=4 learning=5
 	add_trait=mastermind_theologian add_trait=humble add_trait=kind add_trait=diligent add_trait=wroth
 	disallow_random_traits = yes
 	1.8.4={ birth=yes add_trait=creature_dryad immortal_age=18 }
@@ -64,7 +64,7 @@
 	dynasty=128011
 	dna="abesakbdhb"
 	culture=dryad religion=kaldorei_religion
-	martial=14 diplomacy=5 stewardship=3 intrigue=5 learning=10
+	martial=5 diplomacy=5 stewardship=3 intrigue=5 learning=6
 	add_trait=tough_soldier add_trait=wroth add_trait=duelist add_trait=diligent add_trait=strong add_trait=brave
 	disallow_random_traits = yes
 	father=410002
@@ -77,7 +77,7 @@
 	dynasty=128011
 	dna="acesskabfb"
 	culture=dryad religion=kaldorei_religion
-	martial=7 diplomacy=8 stewardship=4 intrigue=5 learning=10
+	martial=7 diplomacy=8 stewardship=4 intrigue=5 learning=6
 	add_trait=mastermind_theologian add_trait=kind add_trait=patient add_trait=diligent add_trait=strong
 	disallow_random_traits = yes
 	father=410000

--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -989,7 +989,7 @@
 	dynasty=20263
 	dna="bobhlaghfph"
 	culture=high_elf religion=cult_of_sunwell
-	martial=6 diplomacy=5 stewardship=14 intrigue=7 learning=8
+	martial=6 diplomacy=5 stewardship=5 intrigue=7 learning=8
 	add_trait=mastermind_theologian add_trait=poet add_trait=erudite add_trait=trusting add_trait=zealous add_trait=diligent add_trait=content
 	200.5.26={ birth=yes add_trait=creature_high_elf immortal_age=18 }
 	604.1.6={ death=yes }
@@ -1037,7 +1037,7 @@
 	dynasty=20016
 	dna="apoomdpnlgb"
 	culture=high_elf religion=cult_of_sunwell
-	martial=9 diplomacy=5 stewardship=5 intrigue=6 learning=5
+	martial=5 diplomacy=5 stewardship=5 intrigue=6 learning=5
 	add_trait=brilliant_strategist add_trait=fair add_trait=brave add_trait=diligent add_trait=stubborn add_trait=patient add_trait=light_foot_leader add_trait=rough_terrain_leader
 	disallow_random_traits = yes
 	father=42085	#Caemis
@@ -1057,7 +1057,7 @@
 	dynasty=20016
 	dna="djgomdpnoga"
 	culture=high_elf religion=cult_of_sunwell
-	martial=9 diplomacy=7 stewardship=4 intrigue=5 learning=5
+	martial=5 diplomacy=7 stewardship=4 intrigue=5 learning=5
 	add_trait=brilliant_strategist add_trait=fair add_trait=brave add_trait=kind add_trait=trusting
 	disallow_random_traits = yes
 	father=42085	#Caemis
@@ -1293,7 +1293,7 @@
 	properties="nd00h000000000"
 	culture=high_elf religion=cult_of_sunwell
 	disallow_random_traits = yes
-	martial=7 diplomacy=4 stewardship=5 intrigue=14 learning=11
+	martial=7 diplomacy=4 stewardship=5 intrigue=7 learning=7
 	add_trait=intricate_webweaver add_trait=proud add_trait=craven add_trait=class_mage_4
 	413.5.4={ birth=yes add_trait=creature_high_elf immortal_age=18 }
 	589.10.26={ death=yes }
@@ -1319,7 +1319,7 @@
 	dna="0ebde0d0ba0"
 	properties="0a0fdf00000000"
 	culture=high_elf religion=cult_of_sunwell
-	martial=12 diplomacy=3 stewardship=13 intrigue=6 learning=10
+	martial=5 diplomacy=3 stewardship=7 intrigue=6 learning=6
 	add_trait=elusive_shadow
 	add_trait=diligent add_trait=shrewd add_trait=gregarious add_trait=patron
 	disallow_random_traits = yes
@@ -1347,7 +1347,7 @@
 	dna="0aaae0b0bc0"
 	properties="0c0fck00000000"
 	culture=high_elf religion=cult_of_sunwell
-	martial=9 diplomacy=9 stewardship=12 intrigue=7 learning=1
+	martial=5 diplomacy=7 stewardship=7 intrigue=7 learning=1
 	add_trait=mastermind_theologian
 	add_trait=diligent add_trait=patient add_trait=shrewd add_trait=patron
 	disallow_random_traits = yes
@@ -1376,7 +1376,7 @@
 	dna="0bae0bae0c0"
 	properties="0c0fck00000000"
 	culture=high_elf religion=cult_of_sunwell
-	martial=14 diplomacy=7 stewardship=4 intrigue=7 learning=3
+	martial=5 diplomacy=7 stewardship=4 intrigue=7 learning=3
 	add_trait=skilled_tactician
 	add_trait=creature_high_elf
 	add_trait=diligent add_trait=patient add_trait=shrewd add_trait=quick add_trait=light_foot_leader add_trait=rough_terrain_leader
@@ -1401,7 +1401,7 @@
 	dynasty=20262
 	dna="mcollinphag"
 	culture=high_elf religion=cult_of_sunwell
-	martial=5 diplomacy=8 stewardship=4 intrigue=5 learning=11
+	martial=5 diplomacy=8 stewardship=4 intrigue=5 learning=7
 	add_trait=scholarly_theologian add_trait=quick add_trait=kind add_trait=patient add_trait=shrewd add_trait = class_mage_5
 	add_trait = creature_high_elf
 	267.7.4={ birth=yes }
@@ -1427,7 +1427,7 @@
 	dynasty=20173
 	dna="akollinphat"
 	culture=high_elf religion=cult_of_sunwell
-	martial=6 diplomacy=5 stewardship=4 intrigue=5 learning=11
+	martial=6 diplomacy=5 stewardship=4 intrigue=5 learning=7
 	add_trait=scholarly_theologian add_trait=wroth add_trait=proud add_trait=scholar add_trait=brave
 	add_trait = creature_high_elf
 	267.7.4={ birth=yes }

--- a/history/characters/46000_gilnean.txt
+++ b/history/characters/46000_gilnean.txt
@@ -16,7 +16,7 @@
 	dna="00gca000ab0"
 	properties="al00gh00000000"
 	culture=gilnean religion=holy_light
-	martial=5 diplomacy=1 stewardship=10 intrigue=3 learning=7
+	martial=5 diplomacy=1 stewardship=6 intrigue=3 learning=7
 	add_trait=skilled_tactician add_trait=stubborn add_trait=shy add_trait=humble add_trait=trusting add_trait = creature_human
 	father=46000	#Archibald
 	disallow_random_traits=yes

--- a/history/characters/48000_tirassian.txt
+++ b/history/characters/48000_tirassian.txt
@@ -1858,7 +1858,7 @@
 	female=yes
 	dna="lbelncdlolb"
 	culture=tirassian religion=tidemother
-	martial=6 diplomacy=6 stewardship=6 intrigue=15 learning=17
+	martial=6 diplomacy=6 stewardship=6 intrigue=6 learning=7
 	add_trait=mastermind_theologian
 	add_trait=fair add_trait=kind add_trait=cruel
 	add_trait=class_mage_8
@@ -2744,7 +2744,7 @@
 	dynasty=26002
 	dna="ancdjnpbcml"
 	culture=tirassian religion=tidemother
-	martial=8 diplomacy=4 stewardship=6 intrigue=6 learning=17
+	martial=8 diplomacy=4 stewardship=6 intrigue=6 learning=7
 	add_trait=charismatic_negotiator add_trait=ambitious add_trait=slothful add_trait=deceitful add_trait=arbitrary 
 	add_trait=cruel add_trait=proud 
 	father=48247	#Serratus
@@ -3688,7 +3688,7 @@
 	female=yes
 	dna="eelbagddnmp"
 	culture=tirassian religion=tidemother
-	martial=5 diplomacy=5 stewardship=7 intrigue=17 learning=6
+	martial=5 diplomacy=5 stewardship=7 intrigue=5 learning=6
 	add_trait=elusive_shadow add_trait=diligent add_trait=just add_trait=wroth add_trait=craven
 	add_trait=class_rogue_5
 	father=48431	#Werinbert
@@ -3701,7 +3701,7 @@
 	dynasty=26003
 	dna="hpcnjfjbghn"
 	culture=tirassian religion=tidemother
-	martial=18 diplomacy=5 stewardship=4 intrigue=5 learning=6
+	martial=5 diplomacy=5 stewardship=4 intrigue=5 learning=6
 	add_trait=tough_soldier add_trait=humble add_trait=trusting add_trait=just 
 	add_trait=class_warrior_5
 	561.7.16={ birth=yes add_trait=creature_human }

--- a/history/characters/57000_amani.txt
+++ b/history/characters/57000_amani.txt
@@ -4,7 +4,7 @@
 	dynasty=8220
 	dna="fdehkcmagac"
 	culture=amani religion=cult_of_loa
-	martial=12 diplomacy=6 stewardship=7 intrigue=6 learning=7
+	martial=6 diplomacy=6 stewardship=7 intrigue=6 learning=7
 	add_trait=brilliant_strategist add_trait=honest add_trait=just add_trait=brave add_trait=ambitious add_trait=patient add_trait = creature_troll
 	disallow_random_traits = yes
 	565.7.24={ 

--- a/history/characters/60000_lordaeronian.txt
+++ b/history/characters/60000_lordaeronian.txt
@@ -67,7 +67,7 @@
 	dna="00dif0i00b0"
 	properties="ad000g00000000"
 	culture=lordaeronian religion=holy_light
-	martial=9 diplomacy=4 stewardship=5 intrigue=5 learning=6
+	martial=5 diplomacy=4 stewardship=5 intrigue=5 learning=6
 	trait=brilliant_strategist trait=wroth trait=robust trait=ambitious
 	disallow_random_traits = yes
 	father=60001	#Terenas
@@ -349,7 +349,7 @@
 	dynasty=30003
 	dna="nkihmdfmpfb"
 	culture=lordaeronian religion=holy_light
-	martial=7 diplomacy=7 stewardship=6 intrigue=3 learning=10
+	martial=7 diplomacy=7 stewardship=6 intrigue=3 learning=6
 	trait=brilliant_strategist trait=charitable trait=kind trait=diligent trait=brave
 	disallow_random_traits = yes
 	549.7.21={ birth=yes add_trait=creature_human }
@@ -516,7 +516,7 @@
 	dynasty=30005
 	dna="nmhjngkgeib"
 	culture=lordaeronian religion=holy_light
-	martial=7 diplomacy=6 stewardship=4 intrigue=5 learning=10
+	martial=7 diplomacy=6 stewardship=4 intrigue=5 learning=6
 	add_trait=brilliant_strategist
 	add_trait=wroth add_trait=temperate add_trait=humble add_trait=brave add_trait=zealous
 	disallow_random_traits=yes
@@ -700,7 +700,7 @@
 	dynasty=30008
 	dna="gpjlcmdaldg"
 	culture=lordaeronian religion=holy_light
-	martial=4 diplomacy=5 stewardship=9 intrigue=7 learning=7
+	martial=4 diplomacy=5 stewardship=6 intrigue=7 learning=7
 	trait=fortune_builder trait=patient trait=diligent trait=erudite
 	disallow_random_traits=yes
 	533.11.10={ birth=yes add_trait=creature_human }
@@ -844,7 +844,7 @@
 	name=Uther
 	dna="jogjokhjeko"
 	culture=lordaeronian religion=holy_light
-	martial=9 diplomacy=6 stewardship=3 intrigue=4 learning=8
+	martial=5 diplomacy=6 stewardship=3 intrigue=4 learning=8
 	trait=brilliant_strategist trait=strong trait=duelist trait=kind trait=charitable trait=just trait=chaste trait=patient trait=erudite
 	disallow_random_traits=yes
 	548.2.26={ birth=yes add_trait=creature_human }
@@ -3094,7 +3094,7 @@
 	name=Turalyon
 	dna="bockaacjnfp"
 	culture=lordaeronian religion=holy_light
-	martial=8 diplomacy=7 stewardship=5 intrigue=6 learning=10
+	martial=8 diplomacy=7 stewardship=5 intrigue=6 learning=6
 	trait=brilliant_strategist trait=brave trait=humble trait=kind trait=charitable
 	trait=diligent trait=just
 	565.1.2={ birth=yes add_trait=creature_human }
@@ -3700,7 +3700,7 @@
 	name=Dartan
 	dynasty=30121
 	culture=alteraci religion=holy_light
-	martial=6 diplomacy=11 stewardship=5 intrigue=0 learning=8
+	martial=6 diplomacy=5 stewardship=5 intrigue=0 learning=8
 	add_trait=martial_cleric add_trait=class_paladin_7 add_trait=adventurer add_trait=diligent add_trait=just add_trait=zealous add_trait=paranoid add_trait=homosexual
 	563.1.15={ birth=yes add_trait=creature_human employer=60001 effect = { add_friend = 60450 add_lover = 60450 }}
 	605.8.10={ death=yes }
@@ -3714,7 +3714,7 @@
 	dna="0keld0f0db0"
 	properties="0l0bak00000000"
 	culture=lordaeronian religion=holy_light
-	martial=1 diplomacy=4 stewardship=8 intrigue=5 learning=13
+	martial=1 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	disallow_random_traits = yes
 	add_trait=brilliant_strategist
 	add_trait=creature_human
@@ -3892,7 +3892,7 @@
 	female=yes
 	add_spouse = 5001
 	culture=lordaeronian religion=arcane_religion
-	martial=6 diplomacy=5 stewardship=7 intrigue=6 learning=9
+	martial=4 diplomacy=4 stewardship=4 intrigue=3 learning=3
 	add_trait=mastermind_theologian
 	add_trait=sorcerer
 	add_trait=scholar

--- a/history/characters/62000_dragon.txt
+++ b/history/characters/62000_dragon.txt
@@ -342,7 +342,7 @@
 	dynasty=38200
 	dna="keegkbflhjj"
 	culture=bronze_dragon religion=sect_of_the_dragons
-	martial=7 diplomacy=9 stewardship=7 intrigue=7 learning=8
+	martial=7 diplomacy=7 stewardship=7 intrigue=7 learning=8
 	add_trait=mastermind_theologian
 	add_trait=aspect_of_time add_trait=diligent add_trait=patient add_trait=humble add_trait=temperate add_trait=chaste add_trait=erudite add_trait=stubborn
 	add_trait=just add_trait=content

--- a/history/characters/66000_zandalari.txt
+++ b/history/characters/66000_zandalari.txt
@@ -34,7 +34,7 @@
 	name=Zul
 	dynasty=8349
 	culture=zandalari religion=cult_of_loa
-	martial=8 diplomacy=10 stewardship=6 intrigue=8 learning=8
+	martial=8 diplomacy=7 stewardship=6 intrigue=8 learning=8
 	add_trait=mastermind_theologian add_trait=ambitious add_trait=quick add_trait=strong add_trait=deceitful
 	disallow_random_traits = yes
 	500.1.1={

--- a/history/characters/75000_old_dwarven.txt
+++ b/history/characters/75000_old_dwarven.txt
@@ -92,7 +92,7 @@
 	dynasty=4542
 	culture=earthen
 	religion=mystery_of_the_makers
-	martial=7 diplomacy=5 stewardship=5 intrigue=4 learning=11
+	martial=7 diplomacy=5 stewardship=5 intrigue=4 learning=7
 	disallow_random_traits = yes
 	trait = creature_earthen
 	trait = midas_touched
@@ -107,7 +107,7 @@
 	dynasty=4543
 	culture=irondwarf
 	religion=cult_of_loken
-	martial=11 diplomacy=5 stewardship=8 intrigue=4 learning=10
+	martial=5 diplomacy=5 stewardship=8 intrigue=4 learning=6
 	disallow_random_traits = yes
 	trait = creature_iron_dwarf
 	trait = skilled_tactician

--- a/history/characters/80000_drakkari.txt
+++ b/history/characters/80000_drakkari.txt
@@ -900,7 +900,7 @@
 	name=Umijo
 	dna="jocaoimdaam"
 	culture=drakkari religion=cult_of_loa
-	martial=8 diplomacy=4 stewardship=8 intrigue=5 learning=12
+	martial=8 diplomacy=4 stewardship=8 intrigue=5 learning=7
 	544.1.7={ birth=yes effect = { dynasty=none}}
 	622.9.24={ death=yes }
 }


### PR DESCRIPTION
Making our balance more like the vanilla one.
Changelog:

- Rearranged wc_uniques.txt according to https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth/blob/master/DEVELOPMENT.md
- Buildings from wc_uniques.txt don't give more prestige than empire title (1.6 prestige) and more than 0.5 piety (vanilla tp_saint_shrine gives 0.3 piety).
- Base attributes are limited to 8, because base attribute above 9 is a kind of supernatural.
- Positive attributes of race traits are limited to 5, because we have a lot of characters with very high attributes because of their races.
- Bloodlines don't give attributes, because they're more about small prestige bonus and opinion.