### PR TITLE
AI Title Destroyers

### DIFF
--- a/common/defines/00_dummy.lua
+++ b/common/defines/00_dummy.lua
@@ -63,3 +63,6 @@ NDefines.NEndGame.DYN15_SCORE = 86000
 NDefines.NEndGame.DYN15_ID = 0
 
 NDefines.NRulerDesigner.MAX_AGE = 30
+
+NDefines.NAI.AI_EMPEROR_CREATES_KINGDOMS = 1
+NDefines.NAI.MAX_KING_TITLES_TO_CREATE = 3


### PR DESCRIPTION
Changelog:
- AI emperors don't mind to hold and create kingdom titles. This fixes the issue where the Alliance and the Horde AI leaders might destroy thier kingdoms after being elected.
- AI don't create more then 3 kingdom tiles.