### PR TITLE
Military Overhaul: the Mercenaries

### DIFF
--- a/common/landed_titles/wc_mercenary_landed_titles.txt
+++ b/common/landed_titles/wc_mercenary_landed_titles.txt
@@ -72,7 +72,7 @@ d_hemets_hunters = {
 	
 	strength_growth_per_century = 1.0
 	
-	mercenary_type = hemets_hunters_composition
+	mercenary_type = beastmasters_composition
 }
 d_dogs_of_war = {
 	color = { 230 230 230 }
@@ -696,7 +696,7 @@ d_northern_company = {
 	
 	strength_growth_per_century = 1.0
 	
-	mercenary_type = northern_composition
+	mercenary_type = beastmasters_composition
 }
 d_goblin_northrend_company = {
 	color = { 102 255 255 }

--- a/common/mercenaries/00_mercenaries.txt
+++ b/common/mercenaries/00_mercenaries.txt
@@ -5,7 +5,7 @@
 ## Must exist or else dynamic mercenary band might fail for nomads!
 default_culture_band_composition = {
 	levy_size = 1
-	light_infantry = 100
+	heavy_infantry = 50
 }
 
 centaur_group_culture_band_composition = {

--- a/common/mercenaries/wc_mercenaries.txt
+++ b/common/mercenaries/wc_mercenaries.txt
@@ -2,180 +2,169 @@
 # Also remember to tell the landed title to use this mercenary type instead.
 # Several titles can refer to the same type as well now.
 
+# IMPORTATN! Sum of units must be 1000
 brotherhood_of_the_horse_composition = {
 	levy_size = 1
-	heavy_infantry = 450
-	light_cavalry = 200
-	archers = 200
+	heavy_infantry = 600
+	light_cavalry = 350
 	elite_infantry = 50
 }
 order_of_the_silver_hand_composition = {
 	levy_size = 4
-	heavy_infantry = 500
-	light_cavalry = 100
-	archers = 150
-	elite_infantry = 100
+	heavy_infantry = 250
+	light_cavalry = 125
+	archers = 450
+	elite_infantry = 175
 }
 scarlet_crusade_composition = {
 	levy_size = 4
-	archers = 250
-	heavy_infantry = 1100
-	light_cavalry = 225
-	elite_infantry = 175
-}
-ymirjar_composition = {
-	levy_size = 4
-	pikemen = 200
-	elite_infantry = 75
-	archers = 250
-	light_cavalry = 50
+	light_infantry = 100
+	heavy_infantry = 400
+	light_cavalry = 150
+	archers = 350
 }
 wardens_composition = {
-	levy_size = 1
-	heavy_infantry = 200
-	archers = 200
-	elite_infantry = 150
+	levy_size = 3
+	archers = 575
+	elite_infantry = 425
 }
 sentinels_composition = {
-	levy_size = 4
-	heavy_infantry = 500
-	archers = 200
+	levy_size = 5.5
+	heavy_infantry = 400
 	light_cavalry = 100
+	archers = 500
 }
 roughnecks_composition = {
 	levy_size = 3
-	archers = 200
-	heavy_infantry = 300
-	knights = 60
+	heavy_infantry = 750
+	knights = 250
 }
 ravenholdt_composition = {
 	levy_size = 1
 	heavy_infantry = 600
-	light_cavalry = 600
-	elite_infantry = 50
+	light_cavalry = 300
+	elite_infantry = 100
 }
-hemets_hunters_composition = {
-	levy_size = 1
-	archers = 1000
+beastmasters_composition = {
+	levy_size = 2
+	heavy_infantry = 400
+	archers = 400
+	animals = 200
 }
 bloodsail_pirates_composition = {
-	levy_size = 1
-	siege_machines = 100
+	levy_size = 2
 	heavy_infantry = 600
 	archers = 300
+	siege_machines = 100
 	# galleys = 40
 }
 dogs_of_war_composition = {
-	levy_size = 1
-	siege_machines = 50
-	heavy_infantry = 500
-	light_cavalry = 200
+	levy_size = 3
+	heavy_infantry = 550
+	light_cavalry = 175
 	archers = 250
+	siege_machines = 50
 }
 stormriggers_composition = {
-	levy_size = 1
-	heavy_infantry = 500
-	archers = 250
+	levy_size = 3
+	archers = 825
+	elite_infantry = 175
 }
 highborne_company_composition = {
 	levy_size = 1
-	heavy_infantry = 500
-	light_infantry = 200
+	light_infantry = 650
+	elite_infantry = 350
 }
 centaur_composition = {
 	levy_size = 1
-	light_cavalry = 500
-	large_cavalry = 75
-	archers = 300
+	light_cavalry = 400
+	horse_archers = 600
 }
 troll_composition = {
-	levy_size = 1
-	heavy_infantry = 700
-	archers = 300
-	light_infantry = 50
+	levy_size = 3
+	light_infantry = 100
+	heavy_infantry = 475
+	pikemen = 100
+	light_cavalry = 100
+	archers = 225
 }
 korkron_composition = {
-	levy_size = 2
-	heavy_infantry = 650
-	elite_infantry = 75
-	light_cavalry = 250
+	levy_size = 4
+	heavy_infantry = 250
+	light_cavalry = 150
+	archers = 450
+	elite_infantry = 150
 }
 taunka_composition = {
-	levy_size = 1
-	heavy_infantry = 700
-	archers = 100
-	light_infantry = 100
+	levy_size = 2
+	light_infantry = 200
+	pikemen = 500
+	archers = 300
 }
 vrykul_composition = {
-	levy_size = 3
-	pikemen = 200
-	heavy_infantry = 250
-	archers = 250
-	light_cavalry = 100
+	levy_size = 2
+	light_infantry = 300
+	pikemen = 450
+	archers = 225
+	dragons = 25
 	# galleys = 80
 }
 frost_vrykul_composition = {
-	levy_size = 1.5
-	heavy_infantry = 500
-	pikemen = 200
-	archers = 300
+	levy_size = 2.5
+	pikemen = 350
+	archers = 550
+	elite_infantry = 100
 }
 wolvar_composition = {
 	levy_size = 1.5
-	heavy_infantry = 450
-	archers = 100
+	heavy_infantry = 300
+	archers = 400
+	thralls = 300
 }
 gorloc_composition = {
-	levy_size = 2
-	heavy_infantry = 500
-	light_infantry = 50
+	levy_size = 1.5
+	light_infantry = 375
+	heavy_infantry = 625
 }
 tuskarr_composition = {
-	levy_size = 1
-	heavy_infantry = 350
-	light_cavalry = 150
-	archers = 100
-}
-northern_composition = {
-	levy_size = 2
-	heavy_infantry = 500
-	light_cavalry = 100
-	archers = 400
+	levy_size = 1.5
+	light_infantry = 100
+	heavy_infantry = 550
+	archers = 300
+	large_cavalry = 50
 }
 goblin_composition = {
-	levy_size = 1
-	archers = 100
+	levy_size = 2.3
 	heavy_infantry = 200
-	knights = 150
-	war_machines = 100
+	archers = 650
+	war_machines = 150
 }
 snobold_composition = {
-	levy_size = 1
-	heavy_infantry = 700
-	archers = 200
-	light_infantry = 100
+	levy_size = 2
+	light_infantry = 225
+	heavy_infantry = 175
+	thralls = 600
 }
 naval_merc_composition = {
 	levy_size = 9
 	galleys = 10
 }
 cenarion_hold_composition = {
-	levy_size = 4
-	heavy_infantry = 350
-	light_infantry = 100
-	archers = 150
-	animals = 250
+	levy_size = 2
+	light_infantry = 400
+	animals = 350
+	elite_infantry = 250
 }
 mage_composition = {
-	levy_size = 2
-	light_infantry = 800
-	archmage = 50
+	levy_size = 3.8
+	light_infantry = 350
+	heavy_infantry = 500
+	archmage = 150
 }
 gnome_composition = {
-	levy_size = 1.5
-	light_infantry = 100
-	heavy_infantry = 500
-	archers = 100
+	levy_size = 2.4
+	heavy_infantry = 250
 	knights = 100
-	war_machines = 100
+	archers = 500
+	war_machines = 150
 }

--- a/common/mercenaries/wc_mercenaries.txt
+++ b/common/mercenaries/wc_mercenaries.txt
@@ -150,9 +150,9 @@ naval_merc_composition = {
 	galleys = 10
 }
 cenarion_hold_composition = {
-	levy_size = 2
-	light_infantry = 400
-	animals = 350
+	levy_size = 1.8
+	light_infantry = 600
+	pikemen = 150
 	elite_infantry = 250
 }
 mage_composition = {

--- a/common/mercenaries/wc_mercenaries.txt
+++ b/common/mercenaries/wc_mercenaries.txt
@@ -2,7 +2,7 @@
 # Also remember to tell the landed title to use this mercenary type instead.
 # Several titles can refer to the same type as well now.
 
-# IMPORTATN! Sum of units must be 1000
+# IMPORTANT! Sum of units must be 1000
 brotherhood_of_the_horse_composition = {
 	levy_size = 1
 	heavy_infantry = 600


### PR DESCRIPTION
Changelog:
- Rebalanced ratio of mercenaries and holy orders. Percentage of range units doesn't exceed 50% of composition cost. Percentage of cavalry units doesn't exceed 50% of composition cost except cavalry-only bands like Centaur Bands.
- Fixed issue where dynamic mercenaries spawned with Casters by default.