### PR TITLE
Remove infection upon becoming demon, fixes #737

### DIFF
--- a/common/scripted_effects/00_scripted_effects.txt
+++ b/common/scripted_effects/00_scripted_effects.txt
@@ -331,14 +331,13 @@ add_trait_severely_injured_effect = {
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
 				25 = { #Get rid of severely_injured but develop infection
+					# Warcraft
+					trigger = {
+						can_get_sick_trigger = yes
+					}
+					
 					set_character_flag = pending_infection
 					character_event = { id = RIP.11000 days = 90 random = 275}
-					
-					# Warcraft
-					modifier = {
-						factor = 0
-						can_get_sick_trigger = no
-					}
 				}
 			}
 		}
@@ -753,6 +752,11 @@ add_trait_silently_severely_injured_effect = {
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
 				25 = { #Get rid of severely_injured but develop infection
+					# Warcraft
+					trigger = {
+						can_get_sick_trigger = yes
+					}
+					
 					set_character_flag = pending_infection
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
@@ -2370,6 +2374,11 @@ prisoner_mutilate_effect = {
 				character_event = { id = RIP.11000 days = 90 random = 275}
 			}
 			25 = { #Get rid of severely_injured but develop infection
+				# Warcraft
+				trigger = {
+					can_get_sick_trigger = yes
+				}
+				
 				set_character_flag = pending_infection
 				character_event = { id = RIP.11000 days = 90 random = 275}
 			}
@@ -2396,6 +2405,11 @@ jailor_mutilate_effect = {
 				character_event = { id = RIP.11000 days = 90 random = 275}
 			}
 			25 = { #Get rid of severely_injured but develop infection
+				# Warcraft
+				trigger = {
+					can_get_sick_trigger = yes
+				}
+				
 				set_character_flag = pending_infection
 				character_event = { id = RIP.11000 days = 90 random = 275}
 			}
@@ -2575,6 +2589,11 @@ maim_hand_effect = {
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
 				25 = { #Get rid of severely_injured but develop infection
+					# Warcraft
+					trigger = {
+						can_get_sick_trigger = yes
+					}
+					
 					set_character_flag = pending_infection
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
@@ -2612,6 +2631,11 @@ mangle_effect = {
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
 				25 = { #Get rid of severely_injured but develop infection
+					# Warcraft
+					trigger = {
+						can_get_sick_trigger = yes
+					}
+					
 					set_character_flag = pending_infection
 					character_event = { id = RIP.11000 days = 90 random = 275}
 				}
@@ -2963,6 +2987,11 @@ resolve_severely_injured_effect = {
 				character_event = { id = RIP.11000 days = 100 random = 300 }
 			}
 			30 = { #Get rid of severely_injured but develop infection
+				# Warcraft
+				trigger = {
+					can_get_sick_trigger = yes
+				}
+				
 				set_character_flag = pending_infection
 				character_event = { id = RIP.11000 days = 100 random = 300 }
 			}

--- a/common/scripted_effects/wc_corruption_scripted_effects.txt
+++ b/common/scripted_effects/wc_corruption_scripted_effects.txt
@@ -709,9 +709,16 @@ clean_dark_beings_effect = {
 		limit = { trait = infertile }
 		remove_trait = infertile
 	}
+	# Remove infection
+	if = { limit = { trait = infection } remove_trait = infection }
 	remove_disease_trait_effect = yes
 	remove_symptoms_effect = yes
 	hidden_effect = {
+		# Remove pending infection from wound prior to becoming demon
+		if = {
+			limit = { has_character_flag = pending_infection }
+			clr_character_flag = pending_infection
+		}
 		remove_disease_flags_effect = yes
 		remove_treatment_modifiers_effect = yes
 	}


### PR DESCRIPTION
First ever actual code PR,  yay?

I work with C++ in my RL job but I'm not familiar with the CK2 standards and environment so I'll take every suggestion/criticism I can use.

The fix is simple really: Clear pending infections (from a wound or something before they became demon) and clear the infection trait once you become a demon. As an aside the clearing of the `pending_infection` flag is wrapped in a `hidden_effect`.