### PR TITLE
Remove Elemental Blessing after conversion

### DIFF
--- a/events/wc_on_action_events.txt
+++ b/events/wc_on_action_events.txt
@@ -9,8 +9,11 @@ character_event = {
 
 	trigger = {
 		OR = {
-			AND = {
-				NOT = { true_religion = old_gods_worship }
+			trigger_if = {
+				limit = {
+					NOT = { true_religion = old_gods_worship }
+					FROM = { true_religion = old_gods_worship }
+				}
 				OR = {
 					has_character_modifier = follower_of_cthun
 					has_character_modifier = follower_of_yogg_saron
@@ -48,14 +51,25 @@ character_event = {
 					has_character_modifier = old_god_blessing_piety_3
 				}
 			}
-			AND = {
-				NOT = { religion = cult_of_loa }
+			trigger_if = {
+				limit = {
+					NOT = { religion = cult_of_loa }
+					FROM = { religion = cult_of_loa }
+				}
 				follower_of_loa = yes
 			}
-			AND = {
-				NOR = {
-					religion_group = shamanism
-					true_religion_group = elemental_lords_group
+			trigger_if = {
+				limit = {
+					NOT = {
+						religion_group = shamanism_group
+						true_religion_group = elemental_lords_group
+					}
+					FROM = {
+						OR = {
+							religion_group = shamanism_group
+							true_religion_group = elemental_lords_group
+						}
+					}
 				}
 				OR = {
 					has_character_modifier = echo_of_the_elements
@@ -76,47 +90,63 @@ character_event = {
 					has_character_modifier = element_blessing_3
 				}
 			}
-			AND = {
-				NOT = { religion = orcish_shamanism }
+			trigger_if = {
+				limit = {
+					NOT = { religion = orcish_shamanism }
+					FROM = { religion = orcish_shamanism }
+				}
 				OR = {
 					has_character_modifier = ancestral_might
 					has_character_modifier = ancestral_guidance
 					has_character_modifier = ancestral_wisdom
 				}
 			}
-			AND = {
-				NOT = { religion = earth_mother_worship }
+			trigger_if = {
+				limit = {
+					NOT = { religion = earth_mother_worship }
+					FROM = { religion = earth_mother_worship }
+				}
 				OR = {
 					has_character_modifier = earth_mother_blessing
 					has_character_modifier = musha_blessing
 					has_character_modifier = anshe_blessing
 				}
 			}
-
-			AND = {
-				NOT = { religion = tidemother }
+			trigger_if = {
+				limit = {
+					NOT = { religion = tidemother }
+					FROM = { religion = tidemother }
+				}
 				OR = {
 					has_character_modifier = lesser_tidesages_blessing
 					has_character_modifier = tidesages_blessing
 				}
 			}
-
-			AND = {
-				NOT = { religion = kaldorei_religion }
+			trigger_if = {
+				limit = {
+					NOT = { religion = kaldorei_religion }
+					FROM = { religion = kaldorei_religion }
+				}
 				OR = {
 					has_character_modifier = elune_blessing
 					has_character_modifier = greater_elune_blessing
 				}
 			}
-			AND = {
-				NOT = { religion = ursine }
+			trigger_if = {
+				limit = {
+					NOT = { religion = ursine }
+					FROM = { religion = ursine }
+				}
 				OR = {
 					has_character_modifier = mark_of_ursoc
 					has_character_modifier = mark_of_ursol
 				}
 			}
-			AND = {
-				NOT = { religion_group = druidism_group }
+			trigger_if = {
+				limit = {
+					NOT = { religion_group = druidism_group }
+					FROM = { religion_group = druidism_group }
+				}
 				OR = {
 					has_character_modifier = blessing_of_ashamane
 					has_character_modifier = blessing_of_aviana
@@ -125,8 +155,11 @@ character_event = {
 					has_character_modifier = blessing_of_malorne
 				}
 			}
-			AND = {
-				NOT = { religion = old_ways }
+			trigger_if = {
+				limit = {
+					NOT = { religion = old_ways }
+					FROM = { religion = old_ways }
+				}
 				OR = {
 					has_character_modifier = potion_of_speech
 					has_character_modifier = potion_of_strength
@@ -140,7 +173,10 @@ character_event = {
 
 	immediate = {
 		if = {
-			limit = { NOT = { true_religion = old_gods_worship } }
+			limit = {
+				NOT = { true_religion = old_gods_worship }
+				FROM = { true_religion = old_gods_worship }
+			}
 			remove_character_modifier = follower_of_cthun
 			remove_character_modifier = follower_of_yogg_saron
 			remove_character_modifier = follower_of_yshaarj
@@ -177,7 +213,10 @@ character_event = {
 			remove_character_modifier = old_god_blessing_piety_3
 		}
 		if = {
-			limit = { NOT = { religion = cult_of_loa } }
+			limit = {
+				NOT = { religion = cult_of_loa }
+				FROM = { religion = cult_of_loa }
+			}
 			remove_character_modifier = follower_of_nalorakk
 			remove_character_modifier = follower_of_akilzon
 			remove_character_modifier = follower_of_janalai
@@ -217,12 +256,18 @@ character_event = {
 			remove_character_modifier = follower_of_zanza
 		}
 		if = {
-			limit = { 
-					NOR = {
-						religion_group = shamanism
-						true_religion_group = elemental_lords_group
-					} 
+			limit = {
+				NOT = {
+					religion_group = shamanism_group
+					true_religion_group = elemental_lords_group
 				}
+				FROM = {
+					OR = {
+						religion_group = shamanism_group
+						true_religion_group = elemental_lords_group
+					}
+				} 
+			}
 			remove_character_modifier = echo_of_the_elements
 			remove_character_modifier = earth_attunement
 			remove_character_modifier = earth_curse
@@ -241,34 +286,52 @@ character_event = {
 			remove_character_modifier = element_blessing_3
 		}
 		if = {
-			limit = { NOT = { religion = orcish_shamanism } }
+			limit = {
+				NOT = { religion = orcish_shamanism }
+				FROM = { religion = orcish_shamanism }
+			}
 			remove_character_modifier = ancestral_might
 			remove_character_modifier = ancestral_guidance
 			remove_character_modifier = ancestral_wisdom
 		}
 		if = {
-			limit = { NOT = { religion = earth_mother_worship } }
+			limit = {
+				NOT = { religion = earth_mother_worship }
+				FROM = { religion = earth_mother_worship }
+			}
 			remove_character_modifier = earth_mother_blessing
 			remove_character_modifier = musha_blessing
 			remove_character_modifier = anshe_blessing
 		}
 		if = {
-			limit = { NOT = { religion = tidemother } }
+			limit = {
+				NOT = { religion = tidemother }
+				FROM = { religion = tidemother }
+			}
 			remove_character_modifier = lesser_tidesages_blessing
 			remove_character_modifier = tidesages_blessing
 		}
 		if = {
-			limit = { NOT = { religion = kaldorei_religion } }
+			limit = {
+				NOT = { religion = kaldorei_religion }
+				FROM = { religion = kaldorei_religion }
+			}
 			remove_character_modifier = elune_blessing
 			remove_character_modifier = greater_elune_blessing
 		}
 		if = {
-			limit = { NOT = { religion = ursine } }
+			limit = {
+				NOT = { religion = ursine }
+				FROM = { religion = ursine }
+			}
 			remove_character_modifier = mark_of_ursoc
 			remove_character_modifier = mark_of_ursol
 		}
 		if = {
-			limit = { NOT = { religion_group = druidism_group } }
+			limit = {
+				NOT = { religion_group = druidism_group }
+				FROM = { religion_group = druidism_group }
+			}
 			remove_character_modifier = blessing_of_ashamane
 			remove_character_modifier = blessing_of_aviana
 			remove_character_modifier = blessing_of_ursoc
@@ -276,7 +339,10 @@ character_event = {
 			remove_character_modifier = blessing_of_malorne
 		}
 		if = {
-			limit = { NOT = { religion = old_ways } }
+			limit = {
+				NOT = { religion = old_ways }
+				FROM = { religion = old_ways }
+			}
 			remove_character_modifier = potion_of_speech
 			remove_character_modifier = potion_of_strength
 			remove_character_modifier = potion_of_thrift

--- a/events/wc_on_action_events.txt
+++ b/events/wc_on_action_events.txt
@@ -71,6 +71,9 @@ character_event = {
 					has_character_modifier = ice_curse
 					has_character_modifier = sand_attunement
 					has_character_modifier = sand_curse
+					has_character_modifier = element_blessing_1
+					has_character_modifier = element_blessing_2
+					has_character_modifier = element_blessing_3
 				}
 			}
 			AND = {
@@ -233,6 +236,9 @@ character_event = {
 			remove_character_modifier = ice_curse
 			remove_character_modifier = sand_attunement
 			remove_character_modifier = sand_curse
+			remove_character_modifier = element_blessing_1
+			remove_character_modifier = element_blessing_2
+			remove_character_modifier = element_blessing_3
 		}
 		if = {
 			limit = { NOT = { religion = orcish_shamanism } }

--- a/events/wc_on_action_events.txt
+++ b/events/wc_on_action_events.txt
@@ -62,12 +62,12 @@ character_event = {
 				limit = {
 					NOT = {
 						religion_group = shamanism_group
-						true_religion_group = elemental_lords_group
+						religion_group = elemental_lords_group
 					}
 					FROM = {
 						OR = {
 							religion_group = shamanism_group
-							true_religion_group = elemental_lords_group
+							religion_group = elemental_lords_group
 						}
 					}
 				}
@@ -259,12 +259,12 @@ character_event = {
 			limit = {
 				NOT = {
 					religion_group = shamanism_group
-					true_religion_group = elemental_lords_group
+					religion_group = elemental_lords_group
 				}
 				FROM = {
 					OR = {
 						religion_group = shamanism_group
-						true_religion_group = elemental_lords_group
+						religion_group = elemental_lords_group
 					}
 				} 
 			}


### PR DESCRIPTION
This should fix #738 and fix #754 (provided it's actually an issue and the blessings aren't meant to stay).

Changelog:
- The Elemental Blessings are now properly removed when religious conversion happens.

Secret changelog:
- Used `trigger_if` and checking of `FROM`'s religion (religion of character before conversion) to make WCONA.5115 event less CPP heavy.
- Fixed `religion_group = shamanism` typo. Religion group is called `shamanism_group`, not `shamanism`.