### PR TITLE
Fix WCUND.135 Localization (Scourge + Legion)

### DIFF
--- a/events/wc_undead_events.txt
+++ b/events/wc_undead_events.txt
@@ -590,6 +590,8 @@ narrative_event = {
 
 	after = {
 		e_burning_legion = { holder_scope = { narrative_event = { id = WCUND.135 } } }
+		
+		clr_global_flag = scourge_is_under_legion_control_flag
 	}
 }
 # Notificates the Legion about the decision

--- a/events/wc_undead_events.txt
+++ b/events/wc_undead_events.txt
@@ -584,11 +584,11 @@ narrative_event = {
 				religion = burning_legion_religion
 			}
 		}
+		
+		clr_global_flag = scourge_is_under_legion_control_flag
 	}
 
 	after = {
-		clr_global_flag = scourge_is_under_legion_control_flag
-		
 		e_burning_legion = { holder_scope = { narrative_event = { id = WCUND.135 } } }
 	}
 }


### PR DESCRIPTION
I obviously can't say if this fix is "best practice", but it actually fixed the issue.

Apparently regardless of whichever option the Lich King chose, alliance or break free, would always have the `scourge_is_under_legion_control_flag` flag cleared so the Legion would always show the "Damn you!!" response.

This happened, apparently, due to how `after` works ("Commands in the after block are executed after an option is selected and run, regardless of which option is chosen").

I've basically made it so the flag is only cleared if the "Break free" option is chosen and otherwise it's not touched by moving it to said scope.

This fixes #713, tested in-game and did not notice any issues.