### PR TITLE
Fix Mind Control Failure not adding traits to target

### DIFF
--- a/events/wc_class_events.txt
+++ b/events/wc_class_events.txt
@@ -1662,7 +1662,7 @@ character_event = {
 				failure = yes
 			}
 		}
-		tooltip = { event_target:target_mind = { add_trait = lunatic } }
+		event_target:target_mind = { add_trait = lunatic }
 		major_soul_corruption_effect = yes
 	}
 }
@@ -1690,7 +1690,7 @@ character_event = {
 			}
 		}
 		add_trait = incapable
-		tooltip = { event_target:target_mind = { add_trait = incapable } }
+		event_target:target_mind = { add_trait = incapable }
 		major_soul_corruption_effect = yes
 	}
 }


### PR DESCRIPTION
Hello there,

Apparently it seems that wrapping the `add_trait` with an `event_target` in a `tooltip` scope does not seem to add it to the target correctly.

Pulling it out of that scope still makes it look fine on the tooltip, as in the screenshots below, and actually applies it to the target.

This PR fixes both issues in #756 (`WCCLS.617` and `WCCLS.618`).

---

**The Screenshots**
<details>
<summary>Lunatic</summary>

![image](https://user-images.githubusercontent.com/439655/65688201-fac6d280-e06a-11e9-90ff-4e73a67225ec.png)

![image](https://user-images.githubusercontent.com/439655/65688217-01554a00-e06b-11e9-809e-7c532e5ade75.png)

</details>

<details>
<summary>Incapable</summary>

![image](https://user-images.githubusercontent.com/439655/65688153-e551a880-e06a-11e9-9611-8b041f2aa3be.png)

![image](https://user-images.githubusercontent.com/439655/65688169-eda9e380-e06a-11e9-99c8-6264fd4a898f.png)
</details>