### PR TITLE
Correct Frostmourne original owner

### DIFF
--- a/events/wc_third_war_events.txt
+++ b/events/wc_third_war_events.txt
@@ -2740,7 +2740,7 @@ narrative_event = {
 		hidden_effect = {
 			new_artifact = {
 				set_creation_date = 591.11.1
-				set_artifact_original_owner = event_target:target_lich_king
+				set_original_owner = event_target:target_lich_king
 			}
 		}
 	}
@@ -2934,7 +2934,7 @@ narrative_event = {
 		hidden_effect = {
 			new_artifact = {
 				set_creation_date = 591.11.1
-				set_artifact_original_owner = event_target:target_lich_king
+				set_original_owner = event_target:target_lich_king
 			}
 		}
 


### PR DESCRIPTION
Hello there,

Apparently Paradox changed something, which took me 5 hours to find (only to be rescued by @zumbak04) without really mentioning it decently.

`set_artifact_original_owner ` was deprecated in favor of `set_original_owner`.

This PR fixes #724.

![image](https://user-images.githubusercontent.com/439655/65717597-0a154280-e0a2-11e9-9600-c6ea8b667214.png)
