### PR TITLE
Buildings don't use allow, use trigger instead

### DIFF
--- a/common/buildings/wc_druidic.txt
+++ b/common/buildings/wc_druidic.txt
@@ -47,12 +47,6 @@ temple = {
 	# World Trees
 	tp_world_tree = {
 		desc = tp_world_tree_desc
-		trigger = {
-			FROM = {
-				religion_group = druidism_group
-				liege = { religion_group = druidism_group }
-			}
-		}
 		potential = {
 			ROOT = { has_province_modifier = world_tree_province_modifier }
 			FROMFROM = {
@@ -86,12 +80,6 @@ temple = {
 	}
 	tp_nightmare_tree = {
 		desc = tp_nightmare_tree_desc
-		trigger = {
-			FROM = {
-				religion = old_gods_worship
-				liege = { religion = old_gods_worship }
-			}
-		}
 		potential = {
 			ROOT = { has_province_modifier = world_tree_province_modifier }
 			FROMFROM = {

--- a/common/buildings/wc_druidic.txt
+++ b/common/buildings/wc_druidic.txt
@@ -47,7 +47,7 @@ temple = {
 	# World Trees
 	tp_world_tree = {
 		desc = tp_world_tree_desc
-		allow = {
+		trigger = {
 			FROM = {
 				religion_group = druidism_group
 				liege = { religion_group = druidism_group }
@@ -86,7 +86,7 @@ temple = {
 	}
 	tp_nightmare_tree = {
 		desc = tp_nightmare_tree_desc
-		allow = {
+		trigger = {
 			FROM = {
 				religion = old_gods_worship
 				liege = { religion = old_gods_worship }

--- a/common/buildings/wc_uniques.txt
+++ b/common/buildings/wc_uniques.txt
@@ -2,7 +2,7 @@ temple = {
 	### WORLD TREES ###
 	tp_nordrassil = {
 		desc = tp_nordrassil_desc
-		allow = {
+		trigger = {
 			FROM = {
 				religion_group = druidism_group
 				liege = { religion_group = druidism_group }

--- a/common/buildings/wc_uniques.txt
+++ b/common/buildings/wc_uniques.txt
@@ -2,12 +2,6 @@ temple = {
 	### WORLD TREES ###
 	tp_nordrassil = {
 		desc = tp_nordrassil_desc
-		trigger = {
-			FROM = {
-				religion_group = druidism_group
-				liege = { religion_group = druidism_group }
-			}
-		}
 		potential = {
 			ROOT = { has_province_modifier = world_tree_province_modifier }
 			FROMFROM = {


### PR DESCRIPTION
Hello there,

Apparently buildings can't use `allow`, but as per the wiki if you want to put restrictions you can use `trigger`: https://ck2.paradoxwikis.com/Building_modding#Changing_restrictions_on_holdings

This PR should fix #726.