### PR TITLE
Fix Dryad Blood not applying

### DIFF
--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -2780,6 +2780,22 @@ add_blood_trait_effect = {
 			}
 			else_if = {
 				limit = {
+					NOT = {
+						trait = creature_dryad
+					}
+					OR = {
+						event_target:target_father = { trait = creature_dryad }
+						event_target:target_mother = { trait = creature_dryad }
+						AND = {
+							event_target:target_father = { trait = blood_dryad }
+							event_target:target_mother = { trait = blood_dryad }
+						}
+					}
+				}
+				add_trait = blood_dryad
+			}
+			else_if = {
+				limit = {
 					NOT = { trait = creature_highborne }
 					OR = {
 						event_target:target_father = { trait = creature_highborne }


### PR DESCRIPTION
Hello there,

This should fix `Dryad Blood` not applying to mixes of Centaur x Dryad and Frost Nymph x Dryad. Keep in mind it won't immediately show up when the child is born as it could take a bit of time. But it will appear.

This PR should fix #772.

![image](https://user-images.githubusercontent.com/439655/65758344-37e99e00-e119-11e9-8bfe-bf06de6dce0b.png)
