### PR TITLE
Aliden Perenolde leads the Syndicate until Classic

### DIFF
--- a/history/characters/58000_alteraci.txt
+++ b/history/characters/58000_alteraci.txt
@@ -64,7 +64,7 @@
 		add_claim=k_alterac
 		add_claim=c_alterac
 	}
-	608.5.11={ death=yes }
+	617.5.11={ death=yes }
 }
 58003={
 	name=Beve

--- a/history/titles/c_headland.txt
+++ b/history/titles/c_headland.txt
@@ -6,6 +6,6 @@
 	holder = 58013
 }
 603.1.1={
-	holder = 58013
+	holder = 58002
 	liege=d_syndicate
 }	

--- a/history/titles/c_strahnbrad.txt
+++ b/history/titles/c_strahnbrad.txt
@@ -5,6 +5,6 @@
 	holder = 58039
 }
 603.1.1={
-	holder=58013
+	holder=58002
 	liege=d_syndicate
 }

--- a/history/titles/d_syndicate.txt
+++ b/history/titles/d_syndicate.txt
@@ -2,5 +2,5 @@
 	law = succ_primogeniture
 }
 603.1.1={
-	holder=58013
+	holder=58002
 }


### PR DESCRIPTION
Hello there,

This makes sure that Aliden Perenolde holds ownership of Strahnbrad and Headlands when he becomes the Syndicate leader.

Also changed his 'forced' death date to 617, which is the year Classic happens in.

This PR should fix #771.