### PR TITLE
Military Overhaul: the Technologies

### DIFF
--- a/common/combat_tactics/00_combat_tactics.txt
+++ b/common/combat_tactics/00_combat_tactics.txt
@@ -30,22 +30,22 @@ generic_skirmish_tactic = {
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 2 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 2 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 4 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 4 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 6 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 6 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 8 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 8 } } }
 		}
 	}
 }
@@ -224,22 +224,22 @@ disorganised_harass_tactic = {
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 2 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 2 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 4 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 4 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 6 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 6 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 8 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 8 } } }
 		}
 	}
 	
@@ -701,22 +701,22 @@ disorganised_swarm_tactic = { # Ditto above
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 2 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 2 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 4 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 4 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 6 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 6 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 8 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 8 } } }
 		}
 	}
 	
@@ -1064,22 +1064,22 @@ prepare_tactic = {
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 2 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 2 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 4 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 4 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 6 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 6 } } }
 		}
 		modifier = {
 			factor = 0.80
 			flank_has_leader = yes
-			leader = { liege = { capital_scope = { TECH_MELEE = 8 } } }
+			leader = { liege = { capital_scope = { TECH_SKIRMISH = 8 } } }
 		}
 	}
 

--- a/common/technology.txt
+++ b/common/technology.txt
@@ -1,86 +1,85 @@
 TECH_GROUP_MILITARY = {
-	TECH_INFANTRY = {	#Conventional Warfare
-		modifier = {
-			heavy_infantry_defensive = 0.60
-			heavy_infantry_morale = 0.40
-
-			archers_defensive = 0.60
-			archers_morale = 0.40
-
-			# light_cavalry
-			light_cavalry_defensive = 0.60
-			horse_archers_defensive = 0.60
-			light_cavalry_morale = 0.40
-			horse_archers_morale = 0.40
-
-			thralls_defensive = 0.60
-			thralls_morale = 0.40
-
-			undead_defensive = 0.60
-			undead_morale = 0.40
-
-			# pikemen
-			pikemen_defensive = 0.60
-			large_cavalry_defensive = 0.60
-			pikemen_morale = 0.40
-			large_cavalry_morale = 0.40
-		}
-	}
-	TECH_CAVALRY = {	#Irregular Warfare
-		modifier = {
-			knights_defensive = 0.60
-			knights_morale = 0.40
-
-			elite_infantry_defensive = 0.60
-			elite_infantry_morale = 0.40
-
-			swarm_defensive = 0.60
-			swarm_morale = 0.40
-
-			dragons_defensive = 0.60
-			dragons_morale = 0.40
-		}
-	}
-	TECH_SKIRMISH = {	#Ley Attunement
+	TECH_INFANTRY = {	# Frontline Troops
 		modifier = {
 			# light_infantry
-			light_infantry_defensive = 0.60
-			light_infantry_morale = 0.40
-			light_infantry_offensive = 0.60
+			light_infantry_defensive = 0.6
+			archmage_defensive = 0.6
+			light_infantry_morale = 0.4
+			archmage_morale = 0.4
+			
+			# heavy_infantry
+			heavy_infantry_defensive = 0.6
+			undead_defensive = 0.6
+			elite_infantry_defensive = 0.6
+			swarm_defensive = 0.6
+			thralls_defensive = 0.6
+			heavy_infantry_morale = 0.4
+			undead_morale = 0.4
+			elite_infantry_morale = 0.4
+			swarm_morale = 0.4
+			thralls_morale = 0.4
 
-			# light_infantry
-			archmage_defensive = 0.60
-			archmage_morale = 0.40
-			archmage_offensive = 0.60
-
-			# light_cavalry
-			# animals get all modifiers here
-			animals_defensive = 0.60
-			animals_morale = 0.40
-			animals_offensive = 0.60
-
-			undead_offensive = 0.60
+			# archers # siege_machines are in TECH_SIEGE_EQUIPMENT
+			archers_defensive = 0.6
+			archers_morale = 0.4
 		}
 	}
-	TECH_MELEE = {	#Tactics Development
+	TECH_CAVALRY = {	# Charging Troops
 		modifier = {
-			heavy_infantry_offensive = 0.60
-			archers_offensive = 0.60
+			# pikemen # war_machines are in TECH_SIEGE_EQUIPMENT
+			pikemen_defensive = 0.6
+			large_cavalry_defensive = 0.6
+			pikemen_morale = 0.4
+			large_cavalry_morale = 0.4
 			
 			# light_cavalry
-			light_cavalry_offensive = 0.60
-			horse_archers_offensive = 0.60
+			light_cavalry_defensive = 0.6
+			horse_archers_defensive = 0.6
+			animals_defensive = 0.6
+			light_cavalry_morale = 0.4
+			horse_archers_morale = 0.4
+			animals_morale = 0.4
 			
-			thralls_offensive = 0.60
-
-			# pikemen
-			pikemen_offensive = 0.60
-			large_cavalry_offensive = 0.60
+			# knights
+			knights_defensive = 0.6
+			dragons_defensive = 0.6
+			knights_morale = 0.4
+			dragons_morale = 0.4
+		}
+	}
+	TECH_SKIRMISH = {	# Skirmish Techniques
+		modifier = {
+			# light_infantry
+			light_infantry_offensive = 0.6
+			archmage_offensive = 0.6
 			
-			elite_infantry_offensive = 0.60
-			knights_offensive = 0.60
-			dragons_offensive = 0.60
-			swarm_offensive = 0.60
+			# horse_archers
+			horse_archers_offensive = 0.6
+			
+			# knights
+			knights_offensive = 0.6
+			dragons_offensive = 0.6
+			
+			# archers # siege_machines are in TECH_SIEGE_EQUIPMENT
+			archers_offensive = 0.6
+		}
+	}
+	TECH_MELEE = {	# Melee Techniques
+		modifier = {
+			# heavy_infantry
+			heavy_infantry_offensive = 0.6
+			undead_offensive = 0.6
+			elite_infantry_offensive = 0.6
+			swarm_offensive = 0.6
+			thralls_offensive = 0.6
+			
+			# pikemen # war_machines are in TECH_SIEGE_EQUIPMENT
+			pikemen_offensive = 0.6
+			large_cavalry_offensive = 0.6
+			
+			# light_cavalry # horse_archers are in TECH_SKIRMISH
+			light_cavalry_offensive = 0.6
+			animals_offensive = 0.6
 		}
 	}
 	TECH_SIEGE_EQUIPMENT = {	#Military Engineering
@@ -88,15 +87,15 @@ TECH_GROUP_MILITARY = {
 			SIEGE_SPEED = 1.0
 			SIEGE_DEFENCE = 1.0
 
-			# heavy_infantry
+			# war_machines
 			war_machines_offensive = 0.60
-			war_machines_morale = 0.40
 			war_machines_defensive = 0.60
+			war_machines_morale = 0.40
 
-			# archers
+			# siege_machines
 			siege_machines_offensive = 0.60
-			siege_machines_morale = 0.40
 			siege_machines_defensive = 0.60
+			siege_machines_morale = 0.40
 		}
 	}
 	TECH_RECRUITMENT = { #Martial Logistics

--- a/localisation/000_wc_military_localization.csv
+++ b/localisation/000_wc_military_localization.csv
@@ -1,11 +1,11 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
 #Military Technologies;;;;;;;;;;;;;;x
 TECH_INFANTRY;Frontline Troops;;;;;;;;;;;;;x
-TECH_CAVALRY;Charging Troops;;;;;;;;;;;;;x
+TECH_CAVALRY;Assault Troops;;;;;;;;;;;;;x
 TECH_SIEGE_EQUIPMENT;Military Engineering;;Wehrtechnik;;;;;;;;;;;x
 TECH_RECRUITMENT;Martial Logistics;;Kriegslogistik;;;;;;;;;;;x
 TECH_INFANTRY_DESC;Better Equipment and Discipline for our Frontline Troops;;;;;;;;;;;;;x
-TECH_CAVALRY_DESC;Better Equipment and Discipline for our Charging Troops;;;;;;;;;;;;;x
+TECH_CAVALRY_DESC;Better Equipment and Discipline for our Assault Troops;;;;;;;;;;;;;x
 TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -Ausrüstung für unsere mechanischen Truppen;;;;;;;;;;;x
 TECH_RECRUITMENT_DESC;More Developed Logistical Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x

--- a/localisation/000_wc_military_localization.csv
+++ b/localisation/000_wc_military_localization.csv
@@ -6,7 +6,7 @@ TECH_SIEGE_EQUIPMENT;Military Engineering;;Wehrtechnik;;;;;;;;;;;x
 TECH_RECRUITMENT;Martial Logistics;;Kriegslogistik;;;;;;;;;;;x
 TECH_INFANTRY_DESC;Better Equipment and Discipline for our Frontline Troops;;;;;;;;;;;;;x
 TECH_CAVALRY_DESC;Better Equipment and Discipline for our Charging Troops;;;;;;;;;;;;;x
-TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -Ausr�stung f�r unsere mechanischen Truppen;;;;;;;;;;;x
+TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -Ausrьstung fьr unsere mechanischen Truppen;;;;;;;;;;;x
 TECH_RECRUITMENT_DESC;More Developed Logistical Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #ABBREVIATIONS;;;;;;;;;;;;;;x
@@ -17,12 +17,12 @@ L_CAV;CV;;KV;;;;;;;;;;;x
 ARCH;RI;;FK;;;;;;;;;;;x
 H_CAV;AI;;GI;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
-PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;Große Infanterie – Angriff;;;;;;;;;;;x
-PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;Große Infanterie – Verteidigung;;;;;;;;;;;x
-PIKEMEN_MORALE;Large Infantry Morale;;Große Infanterie – Moral;;;;;;;;;;;x
-PIKEMEN_MODIFIER;Large Infantry Modifier;;Große Infanterie – Disziplin;;;;;;;;;;;x
-CU_PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
+PIKEMEN;Large Infantry;;GroЯe Infanterie;;;;;;;;;;;x
+PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;GroЯe Infanterie – Angriff;;;;;;;;;;;x
+PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;GroЯe Infanterie – Verteidigung;;;;;;;;;;;x
+PIKEMEN_MORALE;Large Infantry Morale;;GroЯe Infanterie – Moral;;;;;;;;;;;x
+PIKEMEN_MODIFIER;Large Infantry Modifier;;GroЯe Infanterie – Disziplin;;;;;;;;;;;x
+CU_PIKEMEN;Large Infantry;;GroЯe Infanterie;;;;;;;;;;;x
 KNIGHTS;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
 KNIGHTS_OFFENSIVE_FIRE;Aerial Infantry Attack;;Lufteinheiten – Angriff;;;;;;;;;;;x
 KNIGHTS_DEFENSIVE_FIRE;Aerial Infantry Defense;;Lufteinheiten – Verteidigung;;;;;;;;;;;x
@@ -37,12 +37,12 @@ LIGHT_CAVALRY_MORALE;Cavalry Morale;;Kavallerie – Moral;;;;;;;;;;;x
 LIGHT_CAVALRY_MODIFIER;Cavalry Modifier;;Kavallerie – Disziplin;;;;;;;;;;;x
 CU_LIGHT_CAVALRY;Cavalry;;Kavallerie;;;;;;;;;;;x
 CU_CAVALRY;Shock Troops;;;;;;;;;;;;;
-ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
-ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;Fernkämpfer – Angriff;;;;;;;;;;;x
-ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;Fernkämpfer – Verteidigung;;;;;;;;;;;x
-ARCHERS_MORALE;Ranged Infantry Morale;;Fernkämpfer – Moral;;;;;;;;;;;x
-ARCHERS_MODIFIER;Ranged Infantry Modifier;;Fernkämpfer – Disziplin;;;;;;;;;;;x
-CU_ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
+ARCHERS;Ranged Infantry;;Fernkдmpfer;;;;;;;;;;;x
+ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;Fernkдmpfer – Angriff;;;;;;;;;;;x
+ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;Fernkдmpfer – Verteidigung;;;;;;;;;;;x
+ARCHERS_MORALE;Ranged Infantry Morale;;Fernkдmpfer – Moral;;;;;;;;;;;x
+ARCHERS_MODIFIER;Ranged Infantry Modifier;;Fernkдmpfer – Disziplin;;;;;;;;;;;x
+CU_ARCHERS;Ranged Infantry;;Fernkдmpfer;;;;;;;;;;;x
 HEAVY_INFANTRY;Infantry;;Infanterie;;;;;;;;;;;x
 HEAVY_INFANTRY_OFFENSIVE_FIRE;Infantry Attack;;Infanterie – Angriff;;;;;;;;;;;x
 HEAVY_INFANTRY_DEFENSIVE_FIRE;Infantry Defense;;Infanterie – Verteidigung;;;;;;;;;;;x
@@ -55,13 +55,13 @@ LIGHT_INFANTRY_OFFENSIVE_FIRE;Casters Attack;;Zauberer – Angriff;;;;;;;;;;;x
 LIGHT_INFANTRY_DEFENSIVE_FIRE;Casters Defense;;Zauberer – Verteidigung;;;;;;;;;;;x
 LIGHT_INFANTRY_MORALE;Casters Morale;;Zauberer – Moral;;;;;;;;;;;x
 LIGHT_INFANTRY_MODIFIER;Casters Modifier;;Zauberer – Disziplin;;;;;;;;;;;x
-CU_LIGHT_INFANTRY;Support Troops;;Unterstützende Infanterie;;;;;;;;;;;x
+CU_LIGHT_INFANTRY;Support Troops;;Unterstьtzende Infanterie;;;;;;;;;;;x
 CU_ACTUAL_LIGHT_INFANTRY;Casters;;Zauberer;;;;;;;;;;;x
-large_cavalry;Large Cavalry;;Große Kavallerie;;;;;;;;;;;x
-large_cavalry_offensive;Large Cavalry Attack;;Große Kavallerie – Angriff;;;;;;;;;;;x
-large_cavalry_defensive;Large Cavalry Defense;;Große Kavallerie – Verteidigung;;;;;;;;;;;x
-large_cavalry_morale;Large Cavalry Morale;;Große Kavallerie – Moral;;;;;;;;;;;x
-large_cavalry_modifier;Large Cavalry Modifier;;Große Kavallerie – Disziplin;;;;;;;;;;;x
+large_cavalry;Large Cavalry;;GroЯe Kavallerie;;;;;;;;;;;x
+large_cavalry_offensive;Large Cavalry Attack;;GroЯe Kavallerie – Angriff;;;;;;;;;;;x
+large_cavalry_defensive;Large Cavalry Defense;;GroЯe Kavallerie – Verteidigung;;;;;;;;;;;x
+large_cavalry_morale;Large Cavalry Morale;;GroЯe Kavallerie – Moral;;;;;;;;;;;x
+large_cavalry_modifier;Large Cavalry Modifier;;GroЯe Kavallerie – Disziplin;;;;;;;;;;;x
 archmage;Archmage;;Erzmagier;;;;;;;;;;;x
 archmage_offensive;Archmage Attack;;Erzmagier – Angriff;;;;;;;;;;;x
 archmage_defensive;Archmage Defense;;Erzmagier – Verteidigung;;;;;;;;;;;x
@@ -119,10 +119,10 @@ elite_infantry_morale;Elite Infantry Morale;;Eliteinfanterie – Moral;;;;;;;;;;
 elite_infantry_modifier;Elite Infantry Modifier;;Eliteinfanterie – Disziplin;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Tactics;;;;;;;;;;;;;;x
-wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes Geplänkel;;;;;;;;;;;x
-wc_skirmish_tactic;Skirmish;;Geplänkel;;;;;;;;;;;x
+wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes Geplдnkel;;;;;;;;;;;x
+wc_skirmish_tactic;Skirmish;;Geplдnkel;;;;;;;;;;;x
 wc_aerial_raid_tactic;Aerial Raid;;Flugangriff;;;;;;;;;;;x
-wc_aerial_strikes_tactic;Aerial Strikes;;Luftschläge;;;;;;;;;;;x
+wc_aerial_strikes_tactic;Aerial Strikes;;Luftschlдge;;;;;;;;;;;x
 wc_volley_tactic;Volley;;Salve;;;;;;;;;;;x
 wc_magic_volley_tactic;Magic Volley;;Magische Salve;;;;;;;;;;;x
 wc_bombardment_tactic;Bombardment;;Bombardement;;;;;;;;;;;x
@@ -132,41 +132,41 @@ wc_charge_tactic;Charge;;Sturmangriff;;;;;;;;;;;x
 wc_crushing_charge_tactic;Crushing Charge;;Vernichtender Sturmangriff;;;;;;;;;;;x
 wc_undefended_charge_on_flank_tactic;Undefended Charge on Flank;;Deckungsloser Sturmangriff auf die Flanke;;;;;;;;;;;x
 wc_spearhead_tactic;Spearhead;;Speerspitze;;;;;;;;;;;x
-wc_advance_tactic;Advance;;Vorrücken;;;;;;;;;;;x
-wc_push_tactic;Push;;Drängen;;;;;;;;;;;x
+wc_advance_tactic;Advance;;Vorrьcken;;;;;;;;;;;x
+wc_push_tactic;Push;;Drдngen;;;;;;;;;;;x
 wc_pike_wall_tactic;Pike Wall;;Speerwall;;;;;;;;;;;x
 wc_barrier_tactic;Barrier;;Barriere;;;;;;;;;;;x
-wc_overwhelm_tactic;Overwhelm;;Überwältigen;;;;;;;;;;;x
+wc_overwhelm_tactic;Overwhelm;;Ьberwдltigen;;;;;;;;;;;x
 wc_roundabout_charge_tactic;Roundabout Charge;;Rundum-Sturmangriff;;;;;;;;;;;x
 wc_barrage_tactic;Barrage;;Sperrfeuer;;;;;;;;;;;x
-wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und Kämpfen;;;;;;;;;;;x
-wc_raid_tactic;Raid;;Überfall;;;;;;;;;;;x
-wc_overrun_tactic;Overrun;;Überrollen;;;;;;;;;;;x
+wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und Kдmpfen;;;;;;;;;;;x
+wc_raid_tactic;Raid;;Ьberfall;;;;;;;;;;;x
+wc_overrun_tactic;Overrun;;Ьberrollen;;;;;;;;;;;x
 wc_tank_and_heal_tactic;Tank and Heal;;Aufhalten und Heilen;;;;;;;;;;;x
 wc_trample_tactic;Trample;;Niedertrampeln;;;;;;;;;;;x
-wc_reinforce_tactic;Reinforce;;Verstärken;;;;;;;;;;;x
+wc_reinforce_tactic;Reinforce;;Verstдrken;;;;;;;;;;;x
 wc_force_back_tactic;Force Back;;Gegenschlag;;;;;;;;;;;x
 wc_swift_volley_tactic;Swift Volley;;Schnelle Salve;;;;;;;;;;;x
 wc_aimed_bombardment_tactic;Aimed Bombardment;;Gezielte Bombardierung;;;;;;;;;;;x
-wc_draw_out_tactic;Draw Out;;Zurückziehen;;;;;;;;;;;x
+wc_draw_out_tactic;Draw Out;;Zurьckziehen;;;;;;;;;;;x
 wc_aerial_bombardment_tactic ;Aerial Bombardment;;Luftbombardement;;;;;;;;;;;x
 wc_hedgehog_formation_tactic ;Hedgehog Formation;;Igel-Formation;;;;;;;;;;;x
 wc_entrench_tactic ;Entrench;;Eingraben;;;;;;;;;;;x
 wc_heroic_charge_tactic;Heroic Charge;;Heroischer Sturmangriff;;;;;;;;;;;x
 wc_trample_spearhead_tactic;Trample Spearhead;;Speerspitzen-Trampelangriff;;;;;;;;;;;x
-wc_strengthened_barrier_tactic;Strengthened Barrier;;Verstärkte Barriere;;;;;;;;;;;x
+wc_strengthened_barrier_tactic;Strengthened Barrier;;Verstдrkte Barriere;;;;;;;;;;;x
 wc_crafty_ambush_tactic;Crafty Ambush;;Raffinierter Hinterhalt;;;;;;;;;;;x
-wc_religious_zeal_tactic;Religious Zeal;;Religiöser Eifer;;;;;;;;;;;x
-wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische Verstärkung;;;;;;;;;;;x
-wc_slow_harassment_tactic;Slow Harassment;;Langsame Übergriffe;;;;;;;;;;;x
+wc_religious_zeal_tactic;Religious Zeal;;Religiцser Eifer;;;;;;;;;;;x
+wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische Verstдrkung;;;;;;;;;;;x
+wc_slow_harassment_tactic;Slow Harassment;;Langsame Ьbergriffe;;;;;;;;;;;x
 wc_unintentional_charge_tactic;Unintentional Charge;;Unbeabsichtigter Sturmangriff;;;;;;;;;;;x
 wc_fire_on_own_troops_tactic;Fire on Own Troops;;Feuer auf eigene Truppen;;;;;;;;;;;x
-wc_outranged_tactic;Outranged;;Außer Reichweite;;;;;;;;;;;x
+wc_outranged_tactic;Outranged;;AuЯer Reichweite;;;;;;;;;;;x
 wc_aggressive_defense_tactic;Aggressive Defense;;Aggressive Verteidigung;;;;;;;;;;;x
 wc_outstretched_tactic;Outstretched;;Ausgedehnt;;;;;;;;;;;x
-wc_reckless_charge_tactic;Reckless Charge;;Rücksichtsloser Sturmangriff;;;;;;;;;;;x
-wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch Scharmützler;;;;;;;;;;;x
-wc_hesitate_tactic;Hesitate;;Zögern;;;;;;;;;;;x
+wc_reckless_charge_tactic;Reckless Charge;;Rьcksichtsloser Sturmangriff;;;;;;;;;;;x
+wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch Scharmьtzler;;;;;;;;;;;x
+wc_hesitate_tactic;Hesitate;;Zцgern;;;;;;;;;;;x
 wc_failed_barrier_tactic;Failed Barrier;;Fehlgeschlagene Barriere;;;;;;;;;;;x
 wc_advance_in_the_wrong_direction_tactic;Advance in the Wrong Direction;;Fortschritt in die falsche Richtung;;;;;;;;;;;x
 wc_aerial_melee_tactic;Aerial Melee;;Luftnahkampf;;;;;;;;;;;x
@@ -174,31 +174,31 @@ wc_forest_ambush_tactic;Forest Ambush;;Hinterhalt im Wald;;;;;;;;;;;x
 wc_spellbreak_tactic;Spellbreak;;Zauberbruch;;;;;;;;;;;x
 wc_breaking_charge_tactic;Breaking Charge;;Durchbrechender Sturmangriff;;;;;;;;;;;x
 wc_mountain_entrenchment_tactic;Mountain Entrenchment;;Bergeingrabung;;;;;;;;;;;x
-wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der Wüste;;;;;;;;;;;x
+wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der Wьste;;;;;;;;;;;x
 wc_swarm_charge_tactic;Swarm Charge;;Schwarm-Sturmangriff;;;;;;;;;;;x
 wc_swarm_volley_tactic;Swarm Volley;;Schwarm Salve;;;;;;;;;;;x
-wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Übergriffe;;;;;;;;;;;x
+wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Ьbergriffe;;;;;;;;;;;x
 wc_swarm_encircle_tactic;Swarm Encircle;;Schwarmeinkreisung;;;;;;;;;;;x
-wc_overrun_push_tactic;Overrun Push;;Überrennender Stoß;;;;;;;;;;;x
+wc_overrun_push_tactic;Overrun Push;;Ьberrennender StoЯ;;;;;;;;;;;x
 wc_magic_ambush_ractic;Magic Ambush;;Magischer Hinterhalt;;;;;;;;;;;x
-wc_mountain_raid_tactic;Mountain Raid;;Bergüberfall;;;;;;;;;;;x
+wc_mountain_raid_tactic;Mountain Raid;;Bergьberfall;;;;;;;;;;;x
 wc_water_assault_tactic;Water Assault;;Amphibischer Angriff;;;;;;;;;;;x
-wc_commando_raid_tactic;Commando Raid;;Spezialüberfall;;;;;;;;;;;x
+wc_commando_raid_tactic;Commando Raid;;Spezialьberfall;;;;;;;;;;;x
 wc_crush_and_trample_tactic;Crush and Trample;;Zerquetschen und zertrampeln;;;;;;;;;;;x
 wc_underground_ambush_ractic;Underground Ambush;;Unterirdischer Hinterhalt;;;;;;;;;;;x
 wc_brutalizing_trample_tactic;Brutalizing Trample;;Brutales Zertrampeln;;;;;;;;;;;x
 wc_tundra_swarm_tactic;Tundra Swarm;;Tundra-Schwarm;;;;;;;;;;;x
 wc_forest_charge_tactic;Forest Charge;;Waldsturmangriff;;;;;;;;;;;x
 wc_heroic_trample_tactic;Heroic Trample;;Heroisches Zertrampeln;;;;;;;;;;;x
-wc_desert_entrenchment_tactic;Desert Entrenchment;;Wüsteneingrabung;;;;;;;;;;;x
+wc_desert_entrenchment_tactic;Desert Entrenchment;;Wьsteneingrabung;;;;;;;;;;;x
 wc_winter_ambush_tactic;Winter Ambush;;Hinterhalt im Winter;;;;;;;;;;;x
 wc_aerial_ambush_tactic;Aerial Ambush;;Lufthinterhalt;;;;;;;;;;;x
-wc_undead_overrun_tactic;Undead Overrun;;Untotes Überrennen;;;;;;;;;;;x
+wc_undead_overrun_tactic;Undead Overrun;;Untotes Ьberrennen;;;;;;;;;;;x
 wc_undead_spearhead_tactic;Under Spearhead;;Unter der Speerspitze;;;;;;;;;;;x
 wc_null_magic_tactic;Null Magic;;Magie aufheben;;;;;;;;;;;x
 wc_undead_ambush_tactic;Undead Ambush;;Untoter Hinterhalt;;;;;;;;;;;x
 wc_blinding_light_charge_tactic;Blinding Light Charge;;Blendende Lichtladung;;;;;;;;;;;x
-wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhöhter Eifer;;;;;;;;;;;x
+wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhцhter Eifer;;;;;;;;;;;x
 wc_ancient_ambush_tactic;Ancient Ambush;;Urtum-Hinterhalt;;;;;;;;;;;x
 wc_taunt_tactic;Taunt;;Spott;;;;;;;;;;;x
 wc_shield_slam_tactic;Shield Slam;;Schildschlag;;;;;;;;;;;x
@@ -206,8 +206,8 @@ wc_thunderclap_tactic;Thunderclap;;Donnerschlag;;;;;;;;;;;x
 wc_cleave_tactic;Cleave;;Spalten;;;;;;;;;;;x
 wc_multishot_tactic;Multishot;;Mehrfachschuss;;;;;;;;;;;x
 wc_explosive_trap_tactic;Explosive Trap;;Sprengfalle;;;;;;;;;;;x
-wc_kill_command_tactic;Kill Command;;Tötungsbefehl;;;;;;;;;;;x
-wc_disengage_tactic;Disengage;;Lösen;;;;;;;;;;;x
+wc_kill_command_tactic;Kill Command;;Tцtungsbefehl;;;;;;;;;;;x
+wc_disengage_tactic;Disengage;;Lцsen;;;;;;;;;;;x
 wc_distract_tactic;Distract;;Ablenken;;;;;;;;;;;x
 wc_evasion_tactic;Evasion;;Ausweichen;;;;;;;;;;;x
 wc_poisoned_volley_tactic;Poisoned Volley;;Vergiftete Salve;;;;;;;;;;;x
@@ -218,14 +218,14 @@ wc_chains_of_ice_tactic;Chains of Ice;;Eisketten;;;;;;;;;;;x
 wc_death_coil_tactic;Death Coil;;Todesspirale;;;;;;;;;;;x
 wc_blight_bombardment_tactic;Blight Bombardment;;Pesthauch-Bombardement;;;;;;;;;;;x
 wc_raise_undead_tactic;Raise Undead;;Erwecke Untote;;;;;;;;;;;x
-wc_empower_undead_tactic;Empower Undead;;Untote verstärken;;;;;;;;;;;x
-wc_cripple_tactic;Cripple;;Verkrüppeln;;;;;;;;;;;x
+wc_empower_undead_tactic;Empower Undead;;Untote verstдrken;;;;;;;;;;;x
+wc_cripple_tactic;Cripple;;Verkrьppeln;;;;;;;;;;;x
 wc_consume_magic_tactic;Consume Magic;;Magie verzehren;;;;;;;;;;;x
-wc_torment_tactic;Torment;;Quälen;;;;;;;;;;;x
+wc_torment_tactic;Torment;;Quдlen;;;;;;;;;;;x
 wc_immolation_tactic;Immolation;;Feuerbrand;;;;;;;;;;;x
 wc_blade_dance_tactic;Blade Dance;;Klingensturm;;;;;;;;;;;x
 wc_entangling_roots_tactic;Entangling Roots;;Wucherwurzeln;;;;;;;;;;;x
-wc_rejuvenate_tactic;Rejuvenate;;Verjüngung;;;;;;;;;;;x
+wc_rejuvenate_tactic;Rejuvenate;;Verjьngung;;;;;;;;;;;x
 wc_lunar_strike_tactic;Lunar Strike;;Mondschlag;;;;;;;;;;;x
 wc_starfall_tactic;Starfall;;Sternenregen;;;;;;;;;;;x
 wc_arcane_barrage_tactic;Arcane Barrage;;Arkanes Sperrfeuer;;;;;;;;;;;x
@@ -260,7 +260,7 @@ elephant_trample_tactic;Trample;;Zertrampeln;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 # Retinues – Generic;;;;;;;;;;;;;;x
 wc_ret_gen_inf;Infantry Division;;Infanteriedivision;;;;;;;;;;;x
-wc_ret_gen_ran;Ranged Battalion;;Fernkämpferbataillon;;;;;;;;;;;x
+wc_ret_gen_ran;Ranged Battalion;;Fernkдmpferbataillon;;;;;;;;;;;x
 wc_ret_gen_cav;Cavalry Squadron;;Reiterstaffel;;;;;;;;;;;x
 wc_ret_gen_cas;Caster Company;;Zauberertrupp;;;;;;;;;;;x
 wc_ret_gen_aer;Aerial Company;;Fliegerstaffel;;;;;;;;;;;x
@@ -271,7 +271,7 @@ wc_ret_gen_art;Artillery Company;;Artilleriebatterie;;;;;;;;;;;x
 # Retinues – Tribal;;;;;;;;;;;;;;x
 wc_ret_tribe_pure;Tribal Mob;;;;;;;;;;;;;
 wc_ret_tribe_inf;Warriors;;Krieger;;;;;;;;;;;x
-wc_ret_tribe_ran;Hunters;;Jäger;;;;;;;;;;;x
+wc_ret_tribe_ran;Hunters;;Jдger;;;;;;;;;;;x
 wc_ret_tribe_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_tribe_van;Champions;;Champions;;;;;;;;;;;x
 wc_ret_tribe_cas;Totemists;;Totemisten;;;;;;;;;;;x
@@ -279,102 +279,102 @@ wc_ret_tribe_cas;Totemists;;Totemisten;;;;;;;;;;;x
 # Retinues – Cultural;;;;;;;;;;;;;;x
 wc_ret_cul_qiraji;Silithud Swarm;;Silithud-Schwarm;;;;;;;;;;;x
 wc_ret_cul_nerubian;Spiderlords;;Spinnenlords;;;;;;;;;;;x
-wc_ret_cul_centaur;Outrunners;;Vorläufer;;;;;;;;;;;x
+wc_ret_cul_centaur;Outrunners;;Vorlдufer;;;;;;;;;;;x
 wc_ret_cul_eredar;Chaosborn;;Chaosgeborene;;;;;;;;;;;x
-wc_ret_cul_draenei;Peacekeepers;;Friedenswächterinnen;;;;;;;;;;;x
+wc_ret_cul_draenei;Peacekeepers;;Friedenswдchterinnen;;;;;;;;;;;x
 wc_ret_cul_dragon;Drakes;;Drachen;;;;;;;;;;;x
 wc_ret_cul_dryad;Grove Host;;Heerschar des Waldes;;;;;;;;;;;x
-wc_ret_cul_bronzebeard;Mountaineers;;Bergführer;;;;;;;;;;;x
+wc_ret_cul_bronzebeard;Mountaineers;;Bergfьhrer;;;;;;;;;;;x
 wc_ret_cul_wildhammer;Gryphon Knights;;Greifenritter;;;;;;;;;;;x
 wc_ret_cul_darkiron;Dragoons;;Dragoner;;;;;;;;;;;x
 wc_ret_cul_frostborn;Axemasters;;Axtmeister;;;;;;;;;;;x
 wc_ret_cul_furbolg;Ursas;;Ursas;;;;;;;;;;;x
 wc_ret_cul_gnoll;Brutes;;Rohlinge;;;;;;;;;;;x
-wc_ret_cul_wolvar;Tundra Hunters;;Tundra-Jäger;;;;;;;;;;;x
+wc_ret_cul_wolvar;Tundra Hunters;;Tundra-Jдger;;;;;;;;;;;x
 wc_ret_cul_gnome;Commandos;;Kommandotruppen;;;;;;;;;;;x
 wc_ret_cul_goblin;Shredders;;Schredder;;;;;;;;;;;x
 wc_ret_cul_harpy;Roguefeathers;;Schurkenfedern;;;;;;;;;;;x
-wc_ret_cul_highelf;Rangers;;Waldläufer;;;;;;;;;;;x
+wc_ret_cul_highelf;Rangers;;Waldlдufer;;;;;;;;;;;x
 wc_ret_cul_bloodelf;Spellbreakers;;Zauberbrecher;;;;;;;;;;;x
 wc_ret_cul_hozen;Pounders;;Stampfer;;;;;;;;;;;x
 wc_ret_cul_lordaeron;Knights;;Ritter;;;;;;;;;;;x
-wc_ret_cul_gilnean;Greyguard;;Grauwächter;;;;;;;;;;;x
-wc_ret_cul_arathor;Troll Hunters;;Trolljäger;;;;;;;;;;;x
+wc_ret_cul_gilnean;Greyguard;;Grauwдchter;;;;;;;;;;;x
+wc_ret_cul_arathor;Troll Hunters;;Trolljдger;;;;;;;;;;;x
 wc_ret_cul_azeroth;7th Legion;;7. Legion;;;;;;;;;;;x
 wc_ret_cul_dalaran;Archmages;;Erzmagier;;;;;;;;;;;x
-wc_ret_cul_alterac;Mountain Rangers;;Gebirgsjäger;;;;;;;;;;;x
+wc_ret_cul_alterac;Mountain Rangers;;Gebirgsjдger;;;;;;;;;;;x
 wc_ret_cul_tiras;Marines;;Marinesoldaten;;;;;;;;;;;x
-wc_ret_cul_northern;Huntsmen;;Jäger;;;;;;;;;;;x
+wc_ret_cul_northern;Huntsmen;;Jдger;;;;;;;;;;;x
 wc_ret_cul_pirate;Corsairs;;Korsaren;;;;;;;;;;;x
 wc_ret_cul_kobold;Candleholders;;Kerzenhalter;;;;;;;;;;;x
 wc_ret_cul_snobold;Tundra Guard;;Tundra-Wache;;;;;;;;;;;x
 wc_ret_cul_magnataur;Crushers;;Brecher;;;;;;;;;;;x
-wc_ret_cul_murloc;Tide Hunters;;Gezeitenjäger;;;;;;;;;;;x
+wc_ret_cul_murloc;Tide Hunters;;Gezeitenjдger;;;;;;;;;;;x
 wc_ret_cul_gorloc;Oracles;;Orakel;;;;;;;;;;;x
-wc_ret_cul_naga;Royal Guard;;Königliche Wache;;;;;;;;;;;x
-wc_ret_cul_nightelf;Sentinels;;Wächter;;;;;;;;;;;x
-wc_ret_cul_highborne;Archconjurers;;Erzbeschwörer;;;;;;;;;;;x
+wc_ret_cul_naga;Royal Guard;;Kцnigliche Wache;;;;;;;;;;;x
+wc_ret_cul_nightelf;Sentinels;;Wдchter;;;;;;;;;;;x
+wc_ret_cul_highborne;Archconjurers;;Erzbeschwцrer;;;;;;;;;;;x
 wc_ret_cul_ogre;Maulers;;Zerfleischer;;;;;;;;;;;x
 wc_ret_cul_warsong;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_cul_shadowm;Darkcasters;;Dunkelwirker;;;;;;;;;;;x
 wc_ret_cul_blhollow;Savages;;Wilde;;;;;;;;;;;x
-wc_ret_cul_blackrock;Demolishers;;Zerstörer;;;;;;;;;;;x
+wc_ret_cul_blackrock;Demolishers;;Zerstцrer;;;;;;;;;;;x
 wc_ret_cul_bblade;Blademasters;;Klingenmeister;;;;;;;;;;;x
 wc_ret_cul_storeave;Warlocks;;Hexenmeister;;;;;;;;;;;x
 wc_ret_cul_thunlord;Beastmasters;;Bestienmeister;;;;;;;;;;;x
 wc_ret_cul_bonechew;Cannibals;;Kannibalen;;;;;;;;;;;x
 wc_ret_cul_laughskull;Enforcers;;Vollstrecker;;;;;;;;;;;x
 wc_ret_cul_shathand;Gladiators;;Gladiatoren;;;;;;;;;;;x
-wc_ret_cul_frostwolf;Raiders;;Räuber;;;;;;;;;;;x
+wc_ret_cul_frostwolf;Raiders;;Rдuber;;;;;;;;;;;x
 wc_ret_cul_twilhammer;Necrolytes;;Nekrolyten;;;;;;;;;;;x
 wc_ret_cul_dragonmaw;Dragon Riders;;Drachenreiter;;;;;;;;;;;x
 wc_ret_cul_pygmy;Stronglegs;;Starkbeine;;;;;;;;;;;x
 wc_ret_cul_quillboat;Thornguard;;Dornenwache;;;;;;;;;;;x
-wc_ret_cul_satyr;Hellcallers;;Höllenrufer;;;;;;;;;;;x
-wc_ret_cul_sethrak;Desert Raiders;;Wüsten-Räuber;;;;;;;;;;;x
+wc_ret_cul_satyr;Hellcallers;;Hцllenrufer;;;;;;;;;;;x
+wc_ret_cul_sethrak;Desert Raiders;;Wьsten-Rдuber;;;;;;;;;;;x
 wc_ret_cul_tauren;Braves;;Tapfere;;;;;;;;;;;x
 wc_ret_cul_gurubashi;Razzashi Cavalry;;Razzashi Kavallerie;;;;;;;;;;;x
-wc_ret_cul_amani;Guardians;;Wächter;;;;;;;;;;;x
+wc_ret_cul_amani;Guardians;;Wдchter;;;;;;;;;;;x
 wc_ret_cul_zandalari;Warguard;;Kriegsgarde;;;;;;;;;;;x
 wc_ret_cul_drakkari;Lancers;;Lanzenreiter;;;;;;;;;;;x
 wc_ret_cul_darktroll;Trappers;;Fallensteller;;;;;;;;;;;x
-wc_ret_cul_farraki;Assassins;;Attentäter;;;;;;;;;;;x
-wc_ret_cul_bloodtroll;War Mothers;;Kriegsmütter;;;;;;;;;;;x
-we_ret_cul_tuskarr;Turtle Cossacks;;Schildkrötenkosaken;;;;;;;;;;;x
+wc_ret_cul_farraki;Assassins;;Attentдter;;;;;;;;;;;x
+wc_ret_cul_bloodtroll;War Mothers;;Kriegsmьtter;;;;;;;;;;;x
+we_ret_cul_tuskarr;Turtle Cossacks;;Schildkrцtenkosaken;;;;;;;;;;;x
 wc_ret_cul_vrykul;Thanes;;Thanen;;;;;;;;;;;x
-wc_ret_cul_vulpera;Merchant Gunner;;Handelsschützen;;;;;;;;;;;x
+wc_ret_cul_vulpera;Merchant Gunner;;Handelsschьtzen;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 # Retinues – Religious;;;;;;;;;;;;;;x
 wc_ret_rel_scourge;Undead Swarm;;Untoter Schwarm;;;;;;;;;;;x
-wc_ret_rel_scourge2;Frost Wyrms;;Frost-Würmer;;;;;;;;;;;x
+wc_ret_rel_scourge2;Frost Wyrms;;Frost-Wьrmer;;;;;;;;;;;x
 wc_ret_rel_scourge3;Flesh Titans;;Fleisch-Titanen;;;;;;;;;;;x
 wc_ret_rel_scourge4;Death Knights;;Todesritter;;;;;;;;;;;x
 wc_ret_rel_shaytar;Mindless Slaves;;Gedankenlose Sklaven;;;;;;;;;;;x
 wc_ret_rel_shaytar2;Cultists;;Kultisten;;;;;;;;;;;x
 wc_ret_rel_shaytar3;Faceless Reavers;;Gesichtslose Peiniger;;;;;;;;;;;x
 wc_ret_rel_shaytar4;Mutants;;Mutanten;;;;;;;;;;;x
-wc_ret_rel_legion;Lesser Demons;;Niedere Dämonen;;;;;;;;;;;x
-wc_ret_rel_legion2;Greater Demons;;Höhere Dämonen;;;;;;;;;;;x
+wc_ret_rel_legion;Lesser Demons;;Niedere Dдmonen;;;;;;;;;;;x
+wc_ret_rel_legion2;Greater Demons;;Hцhere Dдmonen;;;;;;;;;;;x
 wc_ret_rel_legion3;Fel Reavers;;Fel-Peiniger;;;;;;;;;;;x
-wc_ret_rel_legion4;Doomguard;;Unheilshüter;;;;;;;;;;;x
+wc_ret_rel_legion4;Doomguard;;Unheilshьter;;;;;;;;;;;x
 wc_ret_rel_holylight;Paladins;;Paladine;;;;;;;;;;;x
 wc_ret_rel_cultofloa;Loa Host;;Loa-Heerschar;;;;;;;;;;;x
 wc_ret_rel_cultofloa2;Avatars;;Avatare;;;;;;;;;;;x
-wc_ret_rel_illidari;Demonhunters;;Dämonenjäger;;;;;;;;;;;x
+wc_ret_rel_illidari;Demonhunters;;Dдmonenjдger;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion;Animal Host;;Tierische Heerschar;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion2;Ancients;;Urtume;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 # Retinues – Nomadic;;;;;;;;;;;;;;x
-wc_ret_horde_ani;Raiders;;Räuber;;;;;;;;;;;x
+wc_ret_horde_ani;Raiders;;Rдuber;;;;;;;;;;;x
 wc_ret_horde_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_horde_ran;Marauders;;Marodeure;;;;;;;;;;;x
-wc_ret_horde_cas;Windchasers;;Windjäger;;;;;;;;;;;x
+wc_ret_horde_cas;Windchasers;;Windjдger;;;;;;;;;;;x
 wc_ret_horde_lrg;Battle Lords;;Kampfherren;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Phase Descriptions;;;;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W and §Y[GetLightCavalryName]§W excel in the §YPursue Phase§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fügt Verluste zu.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W und §Y[GetLightCavalryName]§W glänzen in der §YPVerfolgungsphase§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W and §Y[GetHorseArchersName]§W excel in the §YSkirmish Phase§W!;;In der Scharmützelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W und §Y[GetHorseArchersName]§W glänzen in der §YScharmützelphase§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W excel in the §YMelee Phase§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstört wird oder flüchtet.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W glänzen in der §YNahkampfphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W and §Y[GetLightCavalryName]§W excel in the §YPursue Phase§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fьgt Verluste zu.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W und §Y[GetLightCavalryName]§W glдnzen in der §YPVerfolgungsphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W and §Y[GetHorseArchersName]§W excel in the §YSkirmish Phase§W!;;In der Scharmьtzelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W und §Y[GetHorseArchersName]§W glдnzen in der §YScharmьtzelphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W excel in the §YMelee Phase§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstцrt wird oder flьchtet.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W glдnzen in der §YNahkampfphase§W!;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x

--- a/localisation/000_wc_military_localization.csv
+++ b/localisation/000_wc_military_localization.csv
@@ -6,7 +6,7 @@ TECH_SIEGE_EQUIPMENT;Military Engineering;;Wehrtechnik;;;;;;;;;;;x
 TECH_RECRUITMENT;Martial Logistics;;Kriegslogistik;;;;;;;;;;;x
 TECH_INFANTRY_DESC;Better Equipment and Discipline for our Frontline Troops;;;;;;;;;;;;;x
 TECH_CAVALRY_DESC;Better Equipment and Discipline for our Charging Troops;;;;;;;;;;;;;x
-TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -AusrÑŒstung fÑŒr unsere mechanischen Truppen;;;;;;;;;;;x
+TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -Ausrüstung für unsere mechanischen Truppen;;;;;;;;;;;x
 TECH_RECRUITMENT_DESC;More Developed Logistical Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #ABBREVIATIONS;;;;;;;;;;;;;;x
@@ -17,112 +17,112 @@ L_CAV;CV;;KV;;;;;;;;;;;x
 ARCH;RI;;FK;;;;;;;;;;;x
 H_CAV;AI;;GI;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-PIKEMEN;Large Infantry;;GroÐ¯e Infanterie;;;;;;;;;;;x
-PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;GroÐ¯e Infanterie â€“ Angriff;;;;;;;;;;;x
-PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;GroÐ¯e Infanterie â€“ Verteidigung;;;;;;;;;;;x
-PIKEMEN_MORALE;Large Infantry Morale;;GroÐ¯e Infanterie â€“ Moral;;;;;;;;;;;x
-PIKEMEN_MODIFIER;Large Infantry Modifier;;GroÐ¯e Infanterie â€“ Disziplin;;;;;;;;;;;x
-CU_PIKEMEN;Large Infantry;;GroÐ¯e Infanterie;;;;;;;;;;;x
+PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
+PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;Große Infanterie – Angriff;;;;;;;;;;;x
+PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;Große Infanterie – Verteidigung;;;;;;;;;;;x
+PIKEMEN_MORALE;Large Infantry Morale;;Große Infanterie – Moral;;;;;;;;;;;x
+PIKEMEN_MODIFIER;Large Infantry Modifier;;Große Infanterie – Disziplin;;;;;;;;;;;x
+CU_PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
 KNIGHTS;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
-KNIGHTS_OFFENSIVE_FIRE;Aerial Infantry Attack;;Lufteinheiten â€“ Angriff;;;;;;;;;;;x
-KNIGHTS_DEFENSIVE_FIRE;Aerial Infantry Defense;;Lufteinheiten â€“ Verteidigung;;;;;;;;;;;x
-KNIGHTS_MORALE;Aerial Infantry Morale;;Lufteinheiten â€“ Moral;;;;;;;;;;;x
-KNIGHTS_MODIFIER;Aerial Infantry Modifier;;Lufteinheiten â€“ Disziplin;;;;;;;;;;;x
+KNIGHTS_OFFENSIVE_FIRE;Aerial Infantry Attack;;Lufteinheiten – Angriff;;;;;;;;;;;x
+KNIGHTS_DEFENSIVE_FIRE;Aerial Infantry Defense;;Lufteinheiten – Verteidigung;;;;;;;;;;;x
+KNIGHTS_MORALE;Aerial Infantry Morale;;Lufteinheiten – Moral;;;;;;;;;;;x
+KNIGHTS_MODIFIER;Aerial Infantry Modifier;;Lufteinheiten – Disziplin;;;;;;;;;;;x
 CU_KNIGHTS;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
 CU_HEAVY_CAVALRY;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
 LIGHT_CAVALRY;Cavalry;;Kavallerie;;;;;;;;;;;x
-LIGHT_CAVALRY_OFFENSIVE_FIRE;Cavalry Attack;;Kavallerie â€“ Angriff;;;;;;;;;;;x
-LIGHT_CAVALRY_DEFENSIVE_FIRE;Cavalry Defense;;Kavallerie â€“ Verteidigung;;;;;;;;;;;x
-LIGHT_CAVALRY_MORALE;Cavalry Morale;;Kavallerie â€“ Moral;;;;;;;;;;;x
-LIGHT_CAVALRY_MODIFIER;Cavalry Modifier;;Kavallerie â€“ Disziplin;;;;;;;;;;;x
+LIGHT_CAVALRY_OFFENSIVE_FIRE;Cavalry Attack;;Kavallerie – Angriff;;;;;;;;;;;x
+LIGHT_CAVALRY_DEFENSIVE_FIRE;Cavalry Defense;;Kavallerie – Verteidigung;;;;;;;;;;;x
+LIGHT_CAVALRY_MORALE;Cavalry Morale;;Kavallerie – Moral;;;;;;;;;;;x
+LIGHT_CAVALRY_MODIFIER;Cavalry Modifier;;Kavallerie – Disziplin;;;;;;;;;;;x
 CU_LIGHT_CAVALRY;Cavalry;;Kavallerie;;;;;;;;;;;x
 CU_CAVALRY;Shock Troops;;;;;;;;;;;;;
-ARCHERS;Ranged Infantry;;FernkÐ´mpfer;;;;;;;;;;;x
-ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;FernkÐ´mpfer â€“ Angriff;;;;;;;;;;;x
-ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;FernkÐ´mpfer â€“ Verteidigung;;;;;;;;;;;x
-ARCHERS_MORALE;Ranged Infantry Morale;;FernkÐ´mpfer â€“ Moral;;;;;;;;;;;x
-ARCHERS_MODIFIER;Ranged Infantry Modifier;;FernkÐ´mpfer â€“ Disziplin;;;;;;;;;;;x
-CU_ARCHERS;Ranged Infantry;;FernkÐ´mpfer;;;;;;;;;;;x
+ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
+ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;Fernkämpfer – Angriff;;;;;;;;;;;x
+ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;Fernkämpfer – Verteidigung;;;;;;;;;;;x
+ARCHERS_MORALE;Ranged Infantry Morale;;Fernkämpfer – Moral;;;;;;;;;;;x
+ARCHERS_MODIFIER;Ranged Infantry Modifier;;Fernkämpfer – Disziplin;;;;;;;;;;;x
+CU_ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
 HEAVY_INFANTRY;Infantry;;Infanterie;;;;;;;;;;;x
-HEAVY_INFANTRY_OFFENSIVE_FIRE;Infantry Attack;;Infanterie â€“ Angriff;;;;;;;;;;;x
-HEAVY_INFANTRY_DEFENSIVE_FIRE;Infantry Defense;;Infanterie â€“ Verteidigung;;;;;;;;;;;x
-HEAVY_INFANTRY_MORALE;Infantry Morale;;Infanterie â€“ Moral;;;;;;;;;;;x
-HEAVY_INFANTRY_MODIFIER;Infantry Modifier;;Infanterie â€“ Disziplin;;;;;;;;;;;x
+HEAVY_INFANTRY_OFFENSIVE_FIRE;Infantry Attack;;Infanterie – Angriff;;;;;;;;;;;x
+HEAVY_INFANTRY_DEFENSIVE_FIRE;Infantry Defense;;Infanterie – Verteidigung;;;;;;;;;;;x
+HEAVY_INFANTRY_MORALE;Infantry Morale;;Infanterie – Moral;;;;;;;;;;;x
+HEAVY_INFANTRY_MODIFIER;Infantry Modifier;;Infanterie – Disziplin;;;;;;;;;;;x
 CU_HEAVY_INFANTRY;Melee Troops;;Nahkampfinfanterie;;;;;;;;;;;x
 CU_ACTUAL_HEAVY_INFANTRY;Infantry;;Infanterie;;;;;;;;;;;x
 LIGHT_INFANTRY;Casters;;Zauberer;;;;;;;;;;;x
-LIGHT_INFANTRY_OFFENSIVE_FIRE;Casters Attack;;Zauberer â€“ Angriff;;;;;;;;;;;x
-LIGHT_INFANTRY_DEFENSIVE_FIRE;Casters Defense;;Zauberer â€“ Verteidigung;;;;;;;;;;;x
-LIGHT_INFANTRY_MORALE;Casters Morale;;Zauberer â€“ Moral;;;;;;;;;;;x
-LIGHT_INFANTRY_MODIFIER;Casters Modifier;;Zauberer â€“ Disziplin;;;;;;;;;;;x
-CU_LIGHT_INFANTRY;Support Troops;;UnterstÑŒtzende Infanterie;;;;;;;;;;;x
+LIGHT_INFANTRY_OFFENSIVE_FIRE;Casters Attack;;Zauberer – Angriff;;;;;;;;;;;x
+LIGHT_INFANTRY_DEFENSIVE_FIRE;Casters Defense;;Zauberer – Verteidigung;;;;;;;;;;;x
+LIGHT_INFANTRY_MORALE;Casters Morale;;Zauberer – Moral;;;;;;;;;;;x
+LIGHT_INFANTRY_MODIFIER;Casters Modifier;;Zauberer – Disziplin;;;;;;;;;;;x
+CU_LIGHT_INFANTRY;Support Troops;;Unterstützende Infanterie;;;;;;;;;;;x
 CU_ACTUAL_LIGHT_INFANTRY;Casters;;Zauberer;;;;;;;;;;;x
-large_cavalry;Large Cavalry;;GroÐ¯e Kavallerie;;;;;;;;;;;x
-large_cavalry_offensive;Large Cavalry Attack;;GroÐ¯e Kavallerie â€“ Angriff;;;;;;;;;;;x
-large_cavalry_defensive;Large Cavalry Defense;;GroÐ¯e Kavallerie â€“ Verteidigung;;;;;;;;;;;x
-large_cavalry_morale;Large Cavalry Morale;;GroÐ¯e Kavallerie â€“ Moral;;;;;;;;;;;x
-large_cavalry_modifier;Large Cavalry Modifier;;GroÐ¯e Kavallerie â€“ Disziplin;;;;;;;;;;;x
+large_cavalry;Large Cavalry;;Große Kavallerie;;;;;;;;;;;x
+large_cavalry_offensive;Large Cavalry Attack;;Große Kavallerie – Angriff;;;;;;;;;;;x
+large_cavalry_defensive;Large Cavalry Defense;;Große Kavallerie – Verteidigung;;;;;;;;;;;x
+large_cavalry_morale;Large Cavalry Morale;;Große Kavallerie – Moral;;;;;;;;;;;x
+large_cavalry_modifier;Large Cavalry Modifier;;Große Kavallerie – Disziplin;;;;;;;;;;;x
 archmage;Archmage;;Erzmagier;;;;;;;;;;;x
-archmage_offensive;Archmage Attack;;Erzmagier â€“ Angriff;;;;;;;;;;;x
-archmage_defensive;Archmage Defense;;Erzmagier â€“ Verteidigung;;;;;;;;;;;x
-archmage_morale;Archmage Morale;;Erzmagier â€“ Moral;;;;;;;;;;;x
-archmage_modifier;Archmage Modifier;;Erzmagier â€“ Disziplin;;;;;;;;;;;x
+archmage_offensive;Archmage Attack;;Erzmagier – Angriff;;;;;;;;;;;x
+archmage_defensive;Archmage Defense;;Erzmagier – Verteidigung;;;;;;;;;;;x
+archmage_morale;Archmage Morale;;Erzmagier – Moral;;;;;;;;;;;x
+archmage_modifier;Archmage Modifier;;Erzmagier – Disziplin;;;;;;;;;;;x
 undead;Undead;;Ghouls;;;;;;;;;;;x
-undead_offensive;Undead Attack;;Ghouls â€“ Angriff;;;;;;;;;;;x
-undead_defensive;Undead Defense;;Ghouls â€“ Verteidigung;;;;;;;;;;;x
-undead_morale;Undead Morale;;Ghouls â€“ Moral;;;;;;;;;;;x
-undead_modifier;Undead Modifier;;Ghouls â€“ Disziplin;;;;;;;;;;;x
+undead_offensive;Undead Attack;;Ghouls – Angriff;;;;;;;;;;;x
+undead_defensive;Undead Defense;;Ghouls – Verteidigung;;;;;;;;;;;x
+undead_morale;Undead Morale;;Ghouls – Moral;;;;;;;;;;;x
+undead_modifier;Undead Modifier;;Ghouls – Disziplin;;;;;;;;;;;x
 war_machines;War Machines;;Kriegsmaschinen;;;;;;;;;;;x
-war_machines_offensive;War Machine Attack;;Kriegsmaschinen â€“ Angriff;;;;;;;;;;;x
-war_machines_defensive;War Machine Defense;;Kriegsmaschinen â€“ Verteidigung;;;;;;;;;;;x
-war_machines_morale;War Machine Morale;;Kriegsmaschinen â€“ Moral;;;;;;;;;;;x
-war_machines_modifier;War Machine Modifier;;Kriegsmaschinen â€“ Disziplin;;;;;;;;;;;x
+war_machines_offensive;War Machine Attack;;Kriegsmaschinen – Angriff;;;;;;;;;;;x
+war_machines_defensive;War Machine Defense;;Kriegsmaschinen – Verteidigung;;;;;;;;;;;x
+war_machines_morale;War Machine Morale;;Kriegsmaschinen – Moral;;;;;;;;;;;x
+war_machines_modifier;War Machine Modifier;;Kriegsmaschinen – Disziplin;;;;;;;;;;;x
 animals;Animals;;Tiere;;;;;;;;;;;x
-animals_offensive;Animals Attack;;Tiere â€“ Angriff;;;;;;;;;;;x
-animals_defensive;Animals Defense;;Tiere â€“ Verteidigung;;;;;;;;;;;x
-animals_morale;Animals Morale;;Tiere â€“ Moral;;;;;;;;;;;x
-animals_modifier;Animals Modifier;;Tiere â€“ Disziplin;;;;;;;;;;;x
+animals_offensive;Animals Attack;;Tiere – Angriff;;;;;;;;;;;x
+animals_defensive;Animals Defense;;Tiere – Verteidigung;;;;;;;;;;;x
+animals_morale;Animals Morale;;Tiere – Moral;;;;;;;;;;;x
+animals_modifier;Animals Modifier;;Tiere – Disziplin;;;;;;;;;;;x
 dragons;Dragons;;Drachen;;;;;;;;;;;x
-dragons_offensive;Dragons Attack;;Drachen â€“ Angriff;;;;;;;;;;;x
-dragons_defensive;Dragons Defense;;Drachen â€“ Verteidigung;;;;;;;;;;;x
-dragons_morale;Dragons Morale;;Drachen â€“ Moral;;;;;;;;;;;x
-dragons_modifier;Dragons Modifier;;Drachen â€“ Disziplin;;;;;;;;;;;x
+dragons_offensive;Dragons Attack;;Drachen – Angriff;;;;;;;;;;;x
+dragons_defensive;Dragons Defense;;Drachen – Verteidigung;;;;;;;;;;;x
+dragons_morale;Dragons Morale;;Drachen – Moral;;;;;;;;;;;x
+dragons_modifier;Dragons Modifier;;Drachen – Disziplin;;;;;;;;;;;x
 golems;Golems;;;;;;;;;;;;;x
 golems_offensive;Golems Attack;;;;;;;;;;;;;x
 golems_defensive;Golems Defense;;;;;;;;;;;;;x
 golems_morale;Golems Morale;;;;;;;;;;;;;x
 golems_modifier;Golems Modifier;;;;;;;;;;;;;x
 ancients;Ancients;;Urtume;;;;;;;;;;;x
-ancients_offensive;Ancients Attack;;Urtume â€“ Angriff;;;;;;;;;;;x
-ancients_defensive;Ancients Defense;;Urtume â€“ Verteidigung;;;;;;;;;;;x
-ancients_morale;Ancients Morale;;Urtume â€“ Moral;;;;;;;;;;;x
-ancients_modifier;Ancients Modifier;;Urtume â€“ Disziplin;;;;;;;;;;;x
+ancients_offensive;Ancients Attack;;Urtume – Angriff;;;;;;;;;;;x
+ancients_defensive;Ancients Defense;;Urtume – Verteidigung;;;;;;;;;;;x
+ancients_morale;Ancients Morale;;Urtume – Moral;;;;;;;;;;;x
+ancients_modifier;Ancients Modifier;;Urtume – Disziplin;;;;;;;;;;;x
 swarm;Swarm;;Schwarm;;;;;;;;;;;x
-swarm_offensive;Swarm Attack;;Schwarm â€“ Angriff;;;;;;;;;;;x
-swarm_defensive;Swarm Defense;;Schwarm â€“ Verteidigung;;;;;;;;;;;x
-swarm_morale;Swarm Morale;;Schwarm â€“ Moral;;;;;;;;;;;x
-swarm_modifier;Swarm Modifier;;Schwarm â€“ Disziplin;;;;;;;;;;;x
+swarm_offensive;Swarm Attack;;Schwarm – Angriff;;;;;;;;;;;x
+swarm_defensive;Swarm Defense;;Schwarm – Verteidigung;;;;;;;;;;;x
+swarm_morale;Swarm Morale;;Schwarm – Moral;;;;;;;;;;;x
+swarm_modifier;Swarm Modifier;;Schwarm – Disziplin;;;;;;;;;;;x
 siege_machines;Siege Machines;;Belagerungsmaschinen;;;;;;;;;;;x
-siege_machines_offensive;Siege Machine Attack;;Belagerungsmaschinen â€“ Angriff;;;;;;;;;;;x
-siege_machines_defensive;Siege Machine Defense;;Belagerungsmaschinen â€“ Verteidigung;;;;;;;;;;;x
-siege_machines_morale;Siege Machine Morale;;Belagerungsmaschinen â€“ Moral;;;;;;;;;;;x
-siege_machines_modifier;Siege Machine Modifier;;Belagerungsmaschinen â€“ Disziplin;;;;;;;;;;;x
+siege_machines_offensive;Siege Machine Attack;;Belagerungsmaschinen – Angriff;;;;;;;;;;;x
+siege_machines_defensive;Siege Machine Defense;;Belagerungsmaschinen – Verteidigung;;;;;;;;;;;x
+siege_machines_morale;Siege Machine Morale;;Belagerungsmaschinen – Moral;;;;;;;;;;;x
+siege_machines_modifier;Siege Machine Modifier;;Belagerungsmaschinen – Disziplin;;;;;;;;;;;x
 thralls;Thralls;;Leibeigene;;;;;;;;;;;x
-thralls_offensive;Thrall Attack;;Leibeigene â€“ Angriff;;;;;;;;;;;x
-thralls_defensive;Thrall Defense;;Leibeigene â€“ Verteidigung;;;;;;;;;;;x
-thralls_morale;Thrall Morale;;Leibeigene â€“ Moral;;;;;;;;;;;x
-thralls_modifier;Thrall Modifier;;Leibeigene â€“ Disziplin;;;;;;;;;;;x
+thralls_offensive;Thrall Attack;;Leibeigene – Angriff;;;;;;;;;;;x
+thralls_defensive;Thrall Defense;;Leibeigene – Verteidigung;;;;;;;;;;;x
+thralls_morale;Thrall Morale;;Leibeigene – Moral;;;;;;;;;;;x
+thralls_modifier;Thrall Modifier;;Leibeigene – Disziplin;;;;;;;;;;;x
 elite_infantry;Elite Infantry;;Eliteinfanterie;;;;;;;;;;;x
-elite_infantry_offensive;Elite Infantry Attack;;Eliteinfanterie â€“ Angriff;;;;;;;;;;;x
-elite_infantry_defensive;Elite Infantry Defense;;Eliteinfanterie â€“ Verteidigung;;;;;;;;;;;x
-elite_infantry_morale;Elite Infantry Morale;;Eliteinfanterie â€“ Moral;;;;;;;;;;;x
-elite_infantry_modifier;Elite Infantry Modifier;;Eliteinfanterie â€“ Disziplin;;;;;;;;;;;x
+elite_infantry_offensive;Elite Infantry Attack;;Eliteinfanterie – Angriff;;;;;;;;;;;x
+elite_infantry_defensive;Elite Infantry Defense;;Eliteinfanterie – Verteidigung;;;;;;;;;;;x
+elite_infantry_morale;Elite Infantry Morale;;Eliteinfanterie – Moral;;;;;;;;;;;x
+elite_infantry_modifier;Elite Infantry Modifier;;Eliteinfanterie – Disziplin;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Tactics;;;;;;;;;;;;;;x
-wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes GeplÐ´nkel;;;;;;;;;;;x
-wc_skirmish_tactic;Skirmish;;GeplÐ´nkel;;;;;;;;;;;x
+wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes Geplänkel;;;;;;;;;;;x
+wc_skirmish_tactic;Skirmish;;Geplänkel;;;;;;;;;;;x
 wc_aerial_raid_tactic;Aerial Raid;;Flugangriff;;;;;;;;;;;x
-wc_aerial_strikes_tactic;Aerial Strikes;;LuftschlÐ´ge;;;;;;;;;;;x
+wc_aerial_strikes_tactic;Aerial Strikes;;Luftschläge;;;;;;;;;;;x
 wc_volley_tactic;Volley;;Salve;;;;;;;;;;;x
 wc_magic_volley_tactic;Magic Volley;;Magische Salve;;;;;;;;;;;x
 wc_bombardment_tactic;Bombardment;;Bombardement;;;;;;;;;;;x
@@ -132,41 +132,41 @@ wc_charge_tactic;Charge;;Sturmangriff;;;;;;;;;;;x
 wc_crushing_charge_tactic;Crushing Charge;;Vernichtender Sturmangriff;;;;;;;;;;;x
 wc_undefended_charge_on_flank_tactic;Undefended Charge on Flank;;Deckungsloser Sturmangriff auf die Flanke;;;;;;;;;;;x
 wc_spearhead_tactic;Spearhead;;Speerspitze;;;;;;;;;;;x
-wc_advance_tactic;Advance;;VorrÑŒcken;;;;;;;;;;;x
-wc_push_tactic;Push;;DrÐ´ngen;;;;;;;;;;;x
+wc_advance_tactic;Advance;;Vorrücken;;;;;;;;;;;x
+wc_push_tactic;Push;;Drängen;;;;;;;;;;;x
 wc_pike_wall_tactic;Pike Wall;;Speerwall;;;;;;;;;;;x
 wc_barrier_tactic;Barrier;;Barriere;;;;;;;;;;;x
-wc_overwhelm_tactic;Overwhelm;;Ð¬berwÐ´ltigen;;;;;;;;;;;x
+wc_overwhelm_tactic;Overwhelm;;Überwältigen;;;;;;;;;;;x
 wc_roundabout_charge_tactic;Roundabout Charge;;Rundum-Sturmangriff;;;;;;;;;;;x
 wc_barrage_tactic;Barrage;;Sperrfeuer;;;;;;;;;;;x
-wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und KÐ´mpfen;;;;;;;;;;;x
-wc_raid_tactic;Raid;;Ð¬berfall;;;;;;;;;;;x
-wc_overrun_tactic;Overrun;;Ð¬berrollen;;;;;;;;;;;x
+wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und Kämpfen;;;;;;;;;;;x
+wc_raid_tactic;Raid;;Überfall;;;;;;;;;;;x
+wc_overrun_tactic;Overrun;;Überrollen;;;;;;;;;;;x
 wc_tank_and_heal_tactic;Tank and Heal;;Aufhalten und Heilen;;;;;;;;;;;x
 wc_trample_tactic;Trample;;Niedertrampeln;;;;;;;;;;;x
-wc_reinforce_tactic;Reinforce;;VerstÐ´rken;;;;;;;;;;;x
+wc_reinforce_tactic;Reinforce;;Verstärken;;;;;;;;;;;x
 wc_force_back_tactic;Force Back;;Gegenschlag;;;;;;;;;;;x
 wc_swift_volley_tactic;Swift Volley;;Schnelle Salve;;;;;;;;;;;x
 wc_aimed_bombardment_tactic;Aimed Bombardment;;Gezielte Bombardierung;;;;;;;;;;;x
-wc_draw_out_tactic;Draw Out;;ZurÑŒckziehen;;;;;;;;;;;x
+wc_draw_out_tactic;Draw Out;;Zurückziehen;;;;;;;;;;;x
 wc_aerial_bombardment_tactic ;Aerial Bombardment;;Luftbombardement;;;;;;;;;;;x
 wc_hedgehog_formation_tactic ;Hedgehog Formation;;Igel-Formation;;;;;;;;;;;x
 wc_entrench_tactic ;Entrench;;Eingraben;;;;;;;;;;;x
 wc_heroic_charge_tactic;Heroic Charge;;Heroischer Sturmangriff;;;;;;;;;;;x
 wc_trample_spearhead_tactic;Trample Spearhead;;Speerspitzen-Trampelangriff;;;;;;;;;;;x
-wc_strengthened_barrier_tactic;Strengthened Barrier;;VerstÐ´rkte Barriere;;;;;;;;;;;x
+wc_strengthened_barrier_tactic;Strengthened Barrier;;Verstärkte Barriere;;;;;;;;;;;x
 wc_crafty_ambush_tactic;Crafty Ambush;;Raffinierter Hinterhalt;;;;;;;;;;;x
-wc_religious_zeal_tactic;Religious Zeal;;ReligiÑ†ser Eifer;;;;;;;;;;;x
-wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische VerstÐ´rkung;;;;;;;;;;;x
-wc_slow_harassment_tactic;Slow Harassment;;Langsame Ð¬bergriffe;;;;;;;;;;;x
+wc_religious_zeal_tactic;Religious Zeal;;Religiöser Eifer;;;;;;;;;;;x
+wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische Verstärkung;;;;;;;;;;;x
+wc_slow_harassment_tactic;Slow Harassment;;Langsame Übergriffe;;;;;;;;;;;x
 wc_unintentional_charge_tactic;Unintentional Charge;;Unbeabsichtigter Sturmangriff;;;;;;;;;;;x
 wc_fire_on_own_troops_tactic;Fire on Own Troops;;Feuer auf eigene Truppen;;;;;;;;;;;x
-wc_outranged_tactic;Outranged;;AuÐ¯er Reichweite;;;;;;;;;;;x
+wc_outranged_tactic;Outranged;;Außer Reichweite;;;;;;;;;;;x
 wc_aggressive_defense_tactic;Aggressive Defense;;Aggressive Verteidigung;;;;;;;;;;;x
 wc_outstretched_tactic;Outstretched;;Ausgedehnt;;;;;;;;;;;x
-wc_reckless_charge_tactic;Reckless Charge;;RÑŒcksichtsloser Sturmangriff;;;;;;;;;;;x
-wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch ScharmÑŒtzler;;;;;;;;;;;x
-wc_hesitate_tactic;Hesitate;;ZÑ†gern;;;;;;;;;;;x
+wc_reckless_charge_tactic;Reckless Charge;;Rücksichtsloser Sturmangriff;;;;;;;;;;;x
+wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch Scharmützler;;;;;;;;;;;x
+wc_hesitate_tactic;Hesitate;;Zögern;;;;;;;;;;;x
 wc_failed_barrier_tactic;Failed Barrier;;Fehlgeschlagene Barriere;;;;;;;;;;;x
 wc_advance_in_the_wrong_direction_tactic;Advance in the Wrong Direction;;Fortschritt in die falsche Richtung;;;;;;;;;;;x
 wc_aerial_melee_tactic;Aerial Melee;;Luftnahkampf;;;;;;;;;;;x
@@ -174,31 +174,31 @@ wc_forest_ambush_tactic;Forest Ambush;;Hinterhalt im Wald;;;;;;;;;;;x
 wc_spellbreak_tactic;Spellbreak;;Zauberbruch;;;;;;;;;;;x
 wc_breaking_charge_tactic;Breaking Charge;;Durchbrechender Sturmangriff;;;;;;;;;;;x
 wc_mountain_entrenchment_tactic;Mountain Entrenchment;;Bergeingrabung;;;;;;;;;;;x
-wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der WÑŒste;;;;;;;;;;;x
+wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der Wüste;;;;;;;;;;;x
 wc_swarm_charge_tactic;Swarm Charge;;Schwarm-Sturmangriff;;;;;;;;;;;x
 wc_swarm_volley_tactic;Swarm Volley;;Schwarm Salve;;;;;;;;;;;x
-wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Ð¬bergriffe;;;;;;;;;;;x
+wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Übergriffe;;;;;;;;;;;x
 wc_swarm_encircle_tactic;Swarm Encircle;;Schwarmeinkreisung;;;;;;;;;;;x
-wc_overrun_push_tactic;Overrun Push;;Ð¬berrennender StoÐ¯;;;;;;;;;;;x
+wc_overrun_push_tactic;Overrun Push;;Überrennender Stoß;;;;;;;;;;;x
 wc_magic_ambush_ractic;Magic Ambush;;Magischer Hinterhalt;;;;;;;;;;;x
-wc_mountain_raid_tactic;Mountain Raid;;BergÑŒberfall;;;;;;;;;;;x
+wc_mountain_raid_tactic;Mountain Raid;;Bergüberfall;;;;;;;;;;;x
 wc_water_assault_tactic;Water Assault;;Amphibischer Angriff;;;;;;;;;;;x
-wc_commando_raid_tactic;Commando Raid;;SpezialÑŒberfall;;;;;;;;;;;x
+wc_commando_raid_tactic;Commando Raid;;Spezialüberfall;;;;;;;;;;;x
 wc_crush_and_trample_tactic;Crush and Trample;;Zerquetschen und zertrampeln;;;;;;;;;;;x
 wc_underground_ambush_ractic;Underground Ambush;;Unterirdischer Hinterhalt;;;;;;;;;;;x
 wc_brutalizing_trample_tactic;Brutalizing Trample;;Brutales Zertrampeln;;;;;;;;;;;x
 wc_tundra_swarm_tactic;Tundra Swarm;;Tundra-Schwarm;;;;;;;;;;;x
 wc_forest_charge_tactic;Forest Charge;;Waldsturmangriff;;;;;;;;;;;x
 wc_heroic_trample_tactic;Heroic Trample;;Heroisches Zertrampeln;;;;;;;;;;;x
-wc_desert_entrenchment_tactic;Desert Entrenchment;;WÑŒsteneingrabung;;;;;;;;;;;x
+wc_desert_entrenchment_tactic;Desert Entrenchment;;Wüsteneingrabung;;;;;;;;;;;x
 wc_winter_ambush_tactic;Winter Ambush;;Hinterhalt im Winter;;;;;;;;;;;x
 wc_aerial_ambush_tactic;Aerial Ambush;;Lufthinterhalt;;;;;;;;;;;x
-wc_undead_overrun_tactic;Undead Overrun;;Untotes Ð¬berrennen;;;;;;;;;;;x
+wc_undead_overrun_tactic;Undead Overrun;;Untotes Überrennen;;;;;;;;;;;x
 wc_undead_spearhead_tactic;Under Spearhead;;Unter der Speerspitze;;;;;;;;;;;x
 wc_null_magic_tactic;Null Magic;;Magie aufheben;;;;;;;;;;;x
 wc_undead_ambush_tactic;Undead Ambush;;Untoter Hinterhalt;;;;;;;;;;;x
 wc_blinding_light_charge_tactic;Blinding Light Charge;;Blendende Lichtladung;;;;;;;;;;;x
-wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhÑ†hter Eifer;;;;;;;;;;;x
+wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhöhter Eifer;;;;;;;;;;;x
 wc_ancient_ambush_tactic;Ancient Ambush;;Urtum-Hinterhalt;;;;;;;;;;;x
 wc_taunt_tactic;Taunt;;Spott;;;;;;;;;;;x
 wc_shield_slam_tactic;Shield Slam;;Schildschlag;;;;;;;;;;;x
@@ -206,8 +206,8 @@ wc_thunderclap_tactic;Thunderclap;;Donnerschlag;;;;;;;;;;;x
 wc_cleave_tactic;Cleave;;Spalten;;;;;;;;;;;x
 wc_multishot_tactic;Multishot;;Mehrfachschuss;;;;;;;;;;;x
 wc_explosive_trap_tactic;Explosive Trap;;Sprengfalle;;;;;;;;;;;x
-wc_kill_command_tactic;Kill Command;;TÑ†tungsbefehl;;;;;;;;;;;x
-wc_disengage_tactic;Disengage;;LÑ†sen;;;;;;;;;;;x
+wc_kill_command_tactic;Kill Command;;Tötungsbefehl;;;;;;;;;;;x
+wc_disengage_tactic;Disengage;;Lösen;;;;;;;;;;;x
 wc_distract_tactic;Distract;;Ablenken;;;;;;;;;;;x
 wc_evasion_tactic;Evasion;;Ausweichen;;;;;;;;;;;x
 wc_poisoned_volley_tactic;Poisoned Volley;;Vergiftete Salve;;;;;;;;;;;x
@@ -218,14 +218,14 @@ wc_chains_of_ice_tactic;Chains of Ice;;Eisketten;;;;;;;;;;;x
 wc_death_coil_tactic;Death Coil;;Todesspirale;;;;;;;;;;;x
 wc_blight_bombardment_tactic;Blight Bombardment;;Pesthauch-Bombardement;;;;;;;;;;;x
 wc_raise_undead_tactic;Raise Undead;;Erwecke Untote;;;;;;;;;;;x
-wc_empower_undead_tactic;Empower Undead;;Untote verstÐ´rken;;;;;;;;;;;x
-wc_cripple_tactic;Cripple;;VerkrÑŒppeln;;;;;;;;;;;x
+wc_empower_undead_tactic;Empower Undead;;Untote verstärken;;;;;;;;;;;x
+wc_cripple_tactic;Cripple;;Verkrüppeln;;;;;;;;;;;x
 wc_consume_magic_tactic;Consume Magic;;Magie verzehren;;;;;;;;;;;x
-wc_torment_tactic;Torment;;QuÐ´len;;;;;;;;;;;x
+wc_torment_tactic;Torment;;Quälen;;;;;;;;;;;x
 wc_immolation_tactic;Immolation;;Feuerbrand;;;;;;;;;;;x
 wc_blade_dance_tactic;Blade Dance;;Klingensturm;;;;;;;;;;;x
 wc_entangling_roots_tactic;Entangling Roots;;Wucherwurzeln;;;;;;;;;;;x
-wc_rejuvenate_tactic;Rejuvenate;;VerjÑŒngung;;;;;;;;;;;x
+wc_rejuvenate_tactic;Rejuvenate;;Verjüngung;;;;;;;;;;;x
 wc_lunar_strike_tactic;Lunar Strike;;Mondschlag;;;;;;;;;;;x
 wc_starfall_tactic;Starfall;;Sternenregen;;;;;;;;;;;x
 wc_arcane_barrage_tactic;Arcane Barrage;;Arkanes Sperrfeuer;;;;;;;;;;;x
@@ -258,9 +258,9 @@ wc_rain_of_fire_tactic;Rain of Fire;;Feuerregen;;;;;;;;;;;x
 wc_soul_link_tactic;Soul Link;;Seelenverbindung;;;;;;;;;;;x
 elephant_trample_tactic;Trample;;Zertrampeln;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues â€“ Generic;;;;;;;;;;;;;;x
+# Retinues – Generic;;;;;;;;;;;;;;x
 wc_ret_gen_inf;Infantry Division;;Infanteriedivision;;;;;;;;;;;x
-wc_ret_gen_ran;Ranged Battalion;;FernkÐ´mpferbataillon;;;;;;;;;;;x
+wc_ret_gen_ran;Ranged Battalion;;Fernkämpferbataillon;;;;;;;;;;;x
 wc_ret_gen_cav;Cavalry Squadron;;Reiterstaffel;;;;;;;;;;;x
 wc_ret_gen_cas;Caster Company;;Zauberertrupp;;;;;;;;;;;x
 wc_ret_gen_aer;Aerial Company;;Fliegerstaffel;;;;;;;;;;;x
@@ -268,113 +268,113 @@ wc_ret_gen_van;Vanguard Division;;Vorauskommando;;;;;;;;;;;x
 wc_ret_gen_adv;Adventurers;;Abenteurer;;;;;;;;;;;x
 wc_ret_gen_art;Artillery Company;;Artilleriebatterie;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues â€“ Tribal;;;;;;;;;;;;;;x
+# Retinues – Tribal;;;;;;;;;;;;;;x
 wc_ret_tribe_pure;Tribal Mob;;;;;;;;;;;;;
 wc_ret_tribe_inf;Warriors;;Krieger;;;;;;;;;;;x
-wc_ret_tribe_ran;Hunters;;JÐ´ger;;;;;;;;;;;x
+wc_ret_tribe_ran;Hunters;;Jäger;;;;;;;;;;;x
 wc_ret_tribe_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_tribe_van;Champions;;Champions;;;;;;;;;;;x
 wc_ret_tribe_cas;Totemists;;Totemisten;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues â€“ Cultural;;;;;;;;;;;;;;x
+# Retinues – Cultural;;;;;;;;;;;;;;x
 wc_ret_cul_qiraji;Silithud Swarm;;Silithud-Schwarm;;;;;;;;;;;x
 wc_ret_cul_nerubian;Spiderlords;;Spinnenlords;;;;;;;;;;;x
-wc_ret_cul_centaur;Outrunners;;VorlÐ´ufer;;;;;;;;;;;x
+wc_ret_cul_centaur;Outrunners;;Vorläufer;;;;;;;;;;;x
 wc_ret_cul_eredar;Chaosborn;;Chaosgeborene;;;;;;;;;;;x
-wc_ret_cul_draenei;Peacekeepers;;FriedenswÐ´chterinnen;;;;;;;;;;;x
+wc_ret_cul_draenei;Peacekeepers;;Friedenswächterinnen;;;;;;;;;;;x
 wc_ret_cul_dragon;Drakes;;Drachen;;;;;;;;;;;x
 wc_ret_cul_dryad;Grove Host;;Heerschar des Waldes;;;;;;;;;;;x
-wc_ret_cul_bronzebeard;Mountaineers;;BergfÑŒhrer;;;;;;;;;;;x
+wc_ret_cul_bronzebeard;Mountaineers;;Bergführer;;;;;;;;;;;x
 wc_ret_cul_wildhammer;Gryphon Knights;;Greifenritter;;;;;;;;;;;x
 wc_ret_cul_darkiron;Dragoons;;Dragoner;;;;;;;;;;;x
 wc_ret_cul_frostborn;Axemasters;;Axtmeister;;;;;;;;;;;x
 wc_ret_cul_furbolg;Ursas;;Ursas;;;;;;;;;;;x
 wc_ret_cul_gnoll;Brutes;;Rohlinge;;;;;;;;;;;x
-wc_ret_cul_wolvar;Tundra Hunters;;Tundra-JÐ´ger;;;;;;;;;;;x
+wc_ret_cul_wolvar;Tundra Hunters;;Tundra-Jäger;;;;;;;;;;;x
 wc_ret_cul_gnome;Commandos;;Kommandotruppen;;;;;;;;;;;x
 wc_ret_cul_goblin;Shredders;;Schredder;;;;;;;;;;;x
 wc_ret_cul_harpy;Roguefeathers;;Schurkenfedern;;;;;;;;;;;x
-wc_ret_cul_highelf;Rangers;;WaldlÐ´ufer;;;;;;;;;;;x
+wc_ret_cul_highelf;Rangers;;Waldläufer;;;;;;;;;;;x
 wc_ret_cul_bloodelf;Spellbreakers;;Zauberbrecher;;;;;;;;;;;x
 wc_ret_cul_hozen;Pounders;;Stampfer;;;;;;;;;;;x
 wc_ret_cul_lordaeron;Knights;;Ritter;;;;;;;;;;;x
-wc_ret_cul_gilnean;Greyguard;;GrauwÐ´chter;;;;;;;;;;;x
-wc_ret_cul_arathor;Troll Hunters;;TrolljÐ´ger;;;;;;;;;;;x
+wc_ret_cul_gilnean;Greyguard;;Grauwächter;;;;;;;;;;;x
+wc_ret_cul_arathor;Troll Hunters;;Trolljäger;;;;;;;;;;;x
 wc_ret_cul_azeroth;7th Legion;;7. Legion;;;;;;;;;;;x
 wc_ret_cul_dalaran;Archmages;;Erzmagier;;;;;;;;;;;x
-wc_ret_cul_alterac;Mountain Rangers;;GebirgsjÐ´ger;;;;;;;;;;;x
+wc_ret_cul_alterac;Mountain Rangers;;Gebirgsjäger;;;;;;;;;;;x
 wc_ret_cul_tiras;Marines;;Marinesoldaten;;;;;;;;;;;x
-wc_ret_cul_northern;Huntsmen;;JÐ´ger;;;;;;;;;;;x
+wc_ret_cul_northern;Huntsmen;;Jäger;;;;;;;;;;;x
 wc_ret_cul_pirate;Corsairs;;Korsaren;;;;;;;;;;;x
 wc_ret_cul_kobold;Candleholders;;Kerzenhalter;;;;;;;;;;;x
 wc_ret_cul_snobold;Tundra Guard;;Tundra-Wache;;;;;;;;;;;x
 wc_ret_cul_magnataur;Crushers;;Brecher;;;;;;;;;;;x
-wc_ret_cul_murloc;Tide Hunters;;GezeitenjÐ´ger;;;;;;;;;;;x
+wc_ret_cul_murloc;Tide Hunters;;Gezeitenjäger;;;;;;;;;;;x
 wc_ret_cul_gorloc;Oracles;;Orakel;;;;;;;;;;;x
-wc_ret_cul_naga;Royal Guard;;KÑ†nigliche Wache;;;;;;;;;;;x
-wc_ret_cul_nightelf;Sentinels;;WÐ´chter;;;;;;;;;;;x
-wc_ret_cul_highborne;Archconjurers;;ErzbeschwÑ†rer;;;;;;;;;;;x
+wc_ret_cul_naga;Royal Guard;;Königliche Wache;;;;;;;;;;;x
+wc_ret_cul_nightelf;Sentinels;;Wächter;;;;;;;;;;;x
+wc_ret_cul_highborne;Archconjurers;;Erzbeschwörer;;;;;;;;;;;x
 wc_ret_cul_ogre;Maulers;;Zerfleischer;;;;;;;;;;;x
 wc_ret_cul_warsong;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_cul_shadowm;Darkcasters;;Dunkelwirker;;;;;;;;;;;x
 wc_ret_cul_blhollow;Savages;;Wilde;;;;;;;;;;;x
-wc_ret_cul_blackrock;Demolishers;;ZerstÑ†rer;;;;;;;;;;;x
+wc_ret_cul_blackrock;Demolishers;;Zerstörer;;;;;;;;;;;x
 wc_ret_cul_bblade;Blademasters;;Klingenmeister;;;;;;;;;;;x
 wc_ret_cul_storeave;Warlocks;;Hexenmeister;;;;;;;;;;;x
 wc_ret_cul_thunlord;Beastmasters;;Bestienmeister;;;;;;;;;;;x
 wc_ret_cul_bonechew;Cannibals;;Kannibalen;;;;;;;;;;;x
 wc_ret_cul_laughskull;Enforcers;;Vollstrecker;;;;;;;;;;;x
 wc_ret_cul_shathand;Gladiators;;Gladiatoren;;;;;;;;;;;x
-wc_ret_cul_frostwolf;Raiders;;RÐ´uber;;;;;;;;;;;x
+wc_ret_cul_frostwolf;Raiders;;Räuber;;;;;;;;;;;x
 wc_ret_cul_twilhammer;Necrolytes;;Nekrolyten;;;;;;;;;;;x
 wc_ret_cul_dragonmaw;Dragon Riders;;Drachenreiter;;;;;;;;;;;x
 wc_ret_cul_pygmy;Stronglegs;;Starkbeine;;;;;;;;;;;x
 wc_ret_cul_quillboat;Thornguard;;Dornenwache;;;;;;;;;;;x
-wc_ret_cul_satyr;Hellcallers;;HÑ†llenrufer;;;;;;;;;;;x
-wc_ret_cul_sethrak;Desert Raiders;;WÑŒsten-RÐ´uber;;;;;;;;;;;x
+wc_ret_cul_satyr;Hellcallers;;Höllenrufer;;;;;;;;;;;x
+wc_ret_cul_sethrak;Desert Raiders;;Wüsten-Räuber;;;;;;;;;;;x
 wc_ret_cul_tauren;Braves;;Tapfere;;;;;;;;;;;x
 wc_ret_cul_gurubashi;Razzashi Cavalry;;Razzashi Kavallerie;;;;;;;;;;;x
-wc_ret_cul_amani;Guardians;;WÐ´chter;;;;;;;;;;;x
+wc_ret_cul_amani;Guardians;;Wächter;;;;;;;;;;;x
 wc_ret_cul_zandalari;Warguard;;Kriegsgarde;;;;;;;;;;;x
 wc_ret_cul_drakkari;Lancers;;Lanzenreiter;;;;;;;;;;;x
 wc_ret_cul_darktroll;Trappers;;Fallensteller;;;;;;;;;;;x
-wc_ret_cul_farraki;Assassins;;AttentÐ´ter;;;;;;;;;;;x
-wc_ret_cul_bloodtroll;War Mothers;;KriegsmÑŒtter;;;;;;;;;;;x
-we_ret_cul_tuskarr;Turtle Cossacks;;SchildkrÑ†tenkosaken;;;;;;;;;;;x
+wc_ret_cul_farraki;Assassins;;Attentäter;;;;;;;;;;;x
+wc_ret_cul_bloodtroll;War Mothers;;Kriegsmütter;;;;;;;;;;;x
+we_ret_cul_tuskarr;Turtle Cossacks;;Schildkrötenkosaken;;;;;;;;;;;x
 wc_ret_cul_vrykul;Thanes;;Thanen;;;;;;;;;;;x
-wc_ret_cul_vulpera;Merchant Gunner;;HandelsschÑŒtzen;;;;;;;;;;;x
+wc_ret_cul_vulpera;Merchant Gunner;;Handelsschützen;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues â€“ Religious;;;;;;;;;;;;;;x
+# Retinues – Religious;;;;;;;;;;;;;;x
 wc_ret_rel_scourge;Undead Swarm;;Untoter Schwarm;;;;;;;;;;;x
-wc_ret_rel_scourge2;Frost Wyrms;;Frost-WÑŒrmer;;;;;;;;;;;x
+wc_ret_rel_scourge2;Frost Wyrms;;Frost-Würmer;;;;;;;;;;;x
 wc_ret_rel_scourge3;Flesh Titans;;Fleisch-Titanen;;;;;;;;;;;x
 wc_ret_rel_scourge4;Death Knights;;Todesritter;;;;;;;;;;;x
 wc_ret_rel_shaytar;Mindless Slaves;;Gedankenlose Sklaven;;;;;;;;;;;x
 wc_ret_rel_shaytar2;Cultists;;Kultisten;;;;;;;;;;;x
 wc_ret_rel_shaytar3;Faceless Reavers;;Gesichtslose Peiniger;;;;;;;;;;;x
 wc_ret_rel_shaytar4;Mutants;;Mutanten;;;;;;;;;;;x
-wc_ret_rel_legion;Lesser Demons;;Niedere DÐ´monen;;;;;;;;;;;x
-wc_ret_rel_legion2;Greater Demons;;HÑ†here DÐ´monen;;;;;;;;;;;x
+wc_ret_rel_legion;Lesser Demons;;Niedere Dämonen;;;;;;;;;;;x
+wc_ret_rel_legion2;Greater Demons;;Höhere Dämonen;;;;;;;;;;;x
 wc_ret_rel_legion3;Fel Reavers;;Fel-Peiniger;;;;;;;;;;;x
-wc_ret_rel_legion4;Doomguard;;UnheilshÑŒter;;;;;;;;;;;x
+wc_ret_rel_legion4;Doomguard;;Unheilshüter;;;;;;;;;;;x
 wc_ret_rel_holylight;Paladins;;Paladine;;;;;;;;;;;x
 wc_ret_rel_cultofloa;Loa Host;;Loa-Heerschar;;;;;;;;;;;x
 wc_ret_rel_cultofloa2;Avatars;;Avatare;;;;;;;;;;;x
-wc_ret_rel_illidari;Demonhunters;;DÐ´monenjÐ´ger;;;;;;;;;;;x
+wc_ret_rel_illidari;Demonhunters;;Dämonenjäger;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion;Animal Host;;Tierische Heerschar;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion2;Ancients;;Urtume;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues â€“ Nomadic;;;;;;;;;;;;;;x
-wc_ret_horde_ani;Raiders;;RÐ´uber;;;;;;;;;;;x
+# Retinues – Nomadic;;;;;;;;;;;;;;x
+wc_ret_horde_ani;Raiders;;Räuber;;;;;;;;;;;x
 wc_ret_horde_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_horde_ran;Marauders;;Marodeure;;;;;;;;;;;x
-wc_ret_horde_cas;Windchasers;;WindjÐ´ger;;;;;;;;;;;x
+wc_ret_horde_cas;Windchasers;;Windjäger;;;;;;;;;;;x
 wc_ret_horde_lrg;Battle Lords;;Kampfherren;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Phase Descriptions;;;;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\nÂ§Y[GetKnightsName]Â§W, Â§Y[GetHorseArchersName]Â§W, Â§Y[GetDragonsName]Â§W and Â§Y[GetLightCavalryName]Â§W excel in the Â§YPursue PhaseÂ§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fÑŒgt Verluste zu.\nÂ§Y[GetKnightsName]Â§W, Â§Y[GetHorseArchersName]Â§W, Â§Y[GetDragonsName]Â§W und Â§Y[GetLightCavalryName]Â§W glÐ´nzen in der Â§YPVerfolgungsphaseÂ§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\nÂ§Y[GetActualLightInfantryName]Â§W, Â§Y[GetArchersName]Â§W, Â§Y[GetArchmageName]Â§W, Â§Y[GetSiegeMachinesName]Â§W and Â§Y[GetHorseArchersName]Â§W excel in the Â§YSkirmish PhaseÂ§W!;;In der ScharmÑŒtzelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\nÂ§Y[GetActualLightInfantryName]Â§W, Â§Y[GetArchersName]Â§W, Â§Y[GetArchmageName]Â§W, Â§Y[GetSiegeMachinesName]Â§W und Â§Y[GetHorseArchersName]Â§W glÐ´nzen in der Â§YScharmÑŒtzelphaseÂ§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\nÂ§Y[GetActualHeavyInfantryName]Â§W, Â§Y[GetPikemenName]Â§W, Â§Y[GetLightCavalryName]Â§W, Â§Y[GetLargeCavalryName]Â§W, Â§Y[GetUndeadName]Â§W, Â§Y[GetWarMachinesName]Â§W, Â§Y[GetAnimalsName]Â§W, Â§Y[GetEliteInfantryName]Â§W, Â§Y[GetSwarmName]Â§W, Â§Y[GetThrallsName]Â§W excel in the Â§YMelee PhaseÂ§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstÑ†rt wird oder flÑŒchtet.\nÂ§Y[GetActualHeavyInfantryName]Â§W, Â§Y[GetPikemenName]Â§W, Â§Y[GetLightCavalryName]Â§W, Â§Y[GetLargeCavalryName]Â§W, Â§Y[GetUndeadName]Â§W, Â§Y[GetWarMachinesName]Â§W, Â§Y[GetAnimalsName]Â§W, Â§Y[GetEliteInfantryName]Â§W, Â§Y[GetSwarmName]Â§W, Â§Y[GetThrallsName]Â§W glÐ´nzen in der Â§YNahkampfphaseÂ§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W and §Y[GetLightCavalryName]§W excel in the §YPursue Phase§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fügt Verluste zu.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W und §Y[GetLightCavalryName]§W glänzen in der §YPVerfolgungsphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W and §Y[GetHorseArchersName]§W excel in the §YSkirmish Phase§W!;;In der Scharmützelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W und §Y[GetHorseArchersName]§W glänzen in der §YScharmützelphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W excel in the §YMelee Phase§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstört wird oder flüchtet.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W glänzen in der §YNahkampfphase§W!;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x

--- a/localisation/000_wc_military_localization.csv
+++ b/localisation/000_wc_military_localization.csv
@@ -1,17 +1,13 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
 #Military Technologies;;;;;;;;;;;;;;x
-TECH_INFANTRY;Conventional Warfare;;Konventionelle Kriegsführung;;;;;;;;;;;x
-TECH_CAVALRY;Specialized Warfare;;Irreguläre Kriegsführung;;;;;;;;;;;x
-TECH_SKIRMISH;Ley Attunement;;Ley Einstimmung;;;;;;;;;;;x
-TECH_MELEE;Tactics Development;;Taktikentwicklung;;;;;;;;;;;x
+TECH_INFANTRY;Frontline Troops;;;;;;;;;;;;;x
+TECH_CAVALRY;Charging Troops;;;;;;;;;;;;;x
 TECH_SIEGE_EQUIPMENT;Military Engineering;;Wehrtechnik;;;;;;;;;;;x
 TECH_RECRUITMENT;Martial Logistics;;Kriegslogistik;;;;;;;;;;;x
-TECH_INFANTRY_DESC;Better equipment and discipline for our conventional troops;;Bessere Ausrüstung und Disziplin für unsere konventionellen Truppen;;;;;;;;;;;x
-TECH_CAVALRY_DESC;Better equipment and discipline for our more unconventional troops;;Bessere Ausrüstung und Disziplin für unsere Sondereinheiten;;;;;;;;;;;x
-TECH_SKIRMISH_DESC;Better training and discipline for our magically inclined troops;;Bessere Ausbildung und Disziplin für unsere magisch veranlagten Truppen;;;;;;;;;;;x
-TECH_MELEE_DESC;More developed and modern warfare tactics;;Entwickelte und moderne Kriegstaktiken;;;;;;;;;;;x
-TECH_SIEGE_EQUIPMENT_DESC;More advanced siege techniques and equipment for our machine troops;;Fortschrittlichere Belagerungstechniken und -Ausrüstung für unsere mechanischen Truppen;;;;;;;;;;;x
-TECH_RECRUITMENT_DESC;More developed logistic systems and recruitment methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
+TECH_INFANTRY_DESC;Better Equipment and Discipline for our Frontline Troops;;;;;;;;;;;;;x
+TECH_CAVALRY_DESC;Better Equipment and Discipline for our Charging Troops;;;;;;;;;;;;;x
+TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Machine Troops;;Fortschrittlichere Belagerungstechniken und -Ausrüstung für unsere mechanischen Truppen;;;;;;;;;;;x
+TECH_RECRUITMENT_DESC;More Developed Logistic Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #ABBREVIATIONS;;;;;;;;;;;;;;x
 L_INF;CA;;ZA;;;;;;;;;;;x

--- a/localisation/000_wc_military_localization.csv
+++ b/localisation/000_wc_military_localization.csv
@@ -6,8 +6,8 @@ TECH_SIEGE_EQUIPMENT;Military Engineering;;Wehrtechnik;;;;;;;;;;;x
 TECH_RECRUITMENT;Martial Logistics;;Kriegslogistik;;;;;;;;;;;x
 TECH_INFANTRY_DESC;Better Equipment and Discipline for our Frontline Troops;;;;;;;;;;;;;x
 TECH_CAVALRY_DESC;Better Equipment and Discipline for our Charging Troops;;;;;;;;;;;;;x
-TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Machine Troops;;Fortschrittlichere Belagerungstechniken und -Ausrüstung für unsere mechanischen Truppen;;;;;;;;;;;x
-TECH_RECRUITMENT_DESC;More Developed Logistic Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
+TECH_SIEGE_EQUIPMENT_DESC;More Advanced Siege Techniques and Equipment for our Mechanical Troops;;Fortschrittlichere Belagerungstechniken und -Ausrï¿½stung fï¿½r unsere mechanischen Truppen;;;;;;;;;;;x
+TECH_RECRUITMENT_DESC;More Developed Logistical Systems and Recruitment Methods;;Weiterentwickelte Logistiksysteme und Rekrutierungsmethoden;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #ABBREVIATIONS;;;;;;;;;;;;;;x
 L_INF;CA;;ZA;;;;;;;;;;;x
@@ -17,112 +17,112 @@ L_CAV;CV;;KV;;;;;;;;;;;x
 ARCH;RI;;FK;;;;;;;;;;;x
 H_CAV;AI;;GI;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
-PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;Große Infanterie – Angriff;;;;;;;;;;;x
-PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;Große Infanterie – Verteidigung;;;;;;;;;;;x
-PIKEMEN_MORALE;Large Infantry Morale;;Große Infanterie – Moral;;;;;;;;;;;x
-PIKEMEN_MODIFIER;Large Infantry Modifier;;Große Infanterie – Disziplin;;;;;;;;;;;x
-CU_PIKEMEN;Large Infantry;;Große Infanterie;;;;;;;;;;;x
+PIKEMEN;Large Infantry;;GroÃŸe Infanterie;;;;;;;;;;;x
+PIKEMEN_OFFENSIVE_FIRE;Large Infantry Attack;;GroÃŸe Infanterie â€“ Angriff;;;;;;;;;;;x
+PIKEMEN_DEFENSIVE_FIRE;Large Infantry Defense;;GroÃŸe Infanterie â€“ Verteidigung;;;;;;;;;;;x
+PIKEMEN_MORALE;Large Infantry Morale;;GroÃŸe Infanterie â€“ Moral;;;;;;;;;;;x
+PIKEMEN_MODIFIER;Large Infantry Modifier;;GroÃŸe Infanterie â€“ Disziplin;;;;;;;;;;;x
+CU_PIKEMEN;Large Infantry;;GroÃŸe Infanterie;;;;;;;;;;;x
 KNIGHTS;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
-KNIGHTS_OFFENSIVE_FIRE;Aerial Infantry Attack;;Lufteinheiten – Angriff;;;;;;;;;;;x
-KNIGHTS_DEFENSIVE_FIRE;Aerial Infantry Defense;;Lufteinheiten – Verteidigung;;;;;;;;;;;x
-KNIGHTS_MORALE;Aerial Infantry Morale;;Lufteinheiten – Moral;;;;;;;;;;;x
-KNIGHTS_MODIFIER;Aerial Infantry Modifier;;Lufteinheiten – Disziplin;;;;;;;;;;;x
+KNIGHTS_OFFENSIVE_FIRE;Aerial Infantry Attack;;Lufteinheiten â€“ Angriff;;;;;;;;;;;x
+KNIGHTS_DEFENSIVE_FIRE;Aerial Infantry Defense;;Lufteinheiten â€“ Verteidigung;;;;;;;;;;;x
+KNIGHTS_MORALE;Aerial Infantry Morale;;Lufteinheiten â€“ Moral;;;;;;;;;;;x
+KNIGHTS_MODIFIER;Aerial Infantry Modifier;;Lufteinheiten â€“ Disziplin;;;;;;;;;;;x
 CU_KNIGHTS;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
 CU_HEAVY_CAVALRY;Aerial Infantry;;Lufteinheiten;;;;;;;;;;;x
 LIGHT_CAVALRY;Cavalry;;Kavallerie;;;;;;;;;;;x
-LIGHT_CAVALRY_OFFENSIVE_FIRE;Cavalry Attack;;Kavallerie – Angriff;;;;;;;;;;;x
-LIGHT_CAVALRY_DEFENSIVE_FIRE;Cavalry Defense;;Kavallerie – Verteidigung;;;;;;;;;;;x
-LIGHT_CAVALRY_MORALE;Cavalry Morale;;Kavallerie – Moral;;;;;;;;;;;x
-LIGHT_CAVALRY_MODIFIER;Cavalry Modifier;;Kavallerie – Disziplin;;;;;;;;;;;x
+LIGHT_CAVALRY_OFFENSIVE_FIRE;Cavalry Attack;;Kavallerie â€“ Angriff;;;;;;;;;;;x
+LIGHT_CAVALRY_DEFENSIVE_FIRE;Cavalry Defense;;Kavallerie â€“ Verteidigung;;;;;;;;;;;x
+LIGHT_CAVALRY_MORALE;Cavalry Morale;;Kavallerie â€“ Moral;;;;;;;;;;;x
+LIGHT_CAVALRY_MODIFIER;Cavalry Modifier;;Kavallerie â€“ Disziplin;;;;;;;;;;;x
 CU_LIGHT_CAVALRY;Cavalry;;Kavallerie;;;;;;;;;;;x
 CU_CAVALRY;Shock Troops;;;;;;;;;;;;;
-ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
-ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;Fernkämpfer – Angriff;;;;;;;;;;;x
-ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;Fernkämpfer – Verteidigung;;;;;;;;;;;x
-ARCHERS_MORALE;Ranged Infantry Morale;;Fernkämpfer – Moral;;;;;;;;;;;x
-ARCHERS_MODIFIER;Ranged Infantry Modifier;;Fernkämpfer – Disziplin;;;;;;;;;;;x
-CU_ARCHERS;Ranged Infantry;;Fernkämpfer;;;;;;;;;;;x
+ARCHERS;Ranged Infantry;;FernkÃ¤mpfer;;;;;;;;;;;x
+ARCHERS_OFFENSIVE_FIRE;Ranged Infantry Attack;;FernkÃ¤mpfer â€“ Angriff;;;;;;;;;;;x
+ARCHERS_DEFENSIVE_FIRE;Ranged Infantry Defense;;FernkÃ¤mpfer â€“ Verteidigung;;;;;;;;;;;x
+ARCHERS_MORALE;Ranged Infantry Morale;;FernkÃ¤mpfer â€“ Moral;;;;;;;;;;;x
+ARCHERS_MODIFIER;Ranged Infantry Modifier;;FernkÃ¤mpfer â€“ Disziplin;;;;;;;;;;;x
+CU_ARCHERS;Ranged Infantry;;FernkÃ¤mpfer;;;;;;;;;;;x
 HEAVY_INFANTRY;Infantry;;Infanterie;;;;;;;;;;;x
-HEAVY_INFANTRY_OFFENSIVE_FIRE;Infantry Attack;;Infanterie – Angriff;;;;;;;;;;;x
-HEAVY_INFANTRY_DEFENSIVE_FIRE;Infantry Defense;;Infanterie – Verteidigung;;;;;;;;;;;x
-HEAVY_INFANTRY_MORALE;Infantry Morale;;Infanterie – Moral;;;;;;;;;;;x
-HEAVY_INFANTRY_MODIFIER;Infantry Modifier;;Infanterie – Disziplin;;;;;;;;;;;x
+HEAVY_INFANTRY_OFFENSIVE_FIRE;Infantry Attack;;Infanterie â€“ Angriff;;;;;;;;;;;x
+HEAVY_INFANTRY_DEFENSIVE_FIRE;Infantry Defense;;Infanterie â€“ Verteidigung;;;;;;;;;;;x
+HEAVY_INFANTRY_MORALE;Infantry Morale;;Infanterie â€“ Moral;;;;;;;;;;;x
+HEAVY_INFANTRY_MODIFIER;Infantry Modifier;;Infanterie â€“ Disziplin;;;;;;;;;;;x
 CU_HEAVY_INFANTRY;Melee Troops;;Nahkampfinfanterie;;;;;;;;;;;x
 CU_ACTUAL_HEAVY_INFANTRY;Infantry;;Infanterie;;;;;;;;;;;x
 LIGHT_INFANTRY;Casters;;Zauberer;;;;;;;;;;;x
-LIGHT_INFANTRY_OFFENSIVE_FIRE;Casters Attack;;Zauberer – Angriff;;;;;;;;;;;x
-LIGHT_INFANTRY_DEFENSIVE_FIRE;Casters Defense;;Zauberer – Verteidigung;;;;;;;;;;;x
-LIGHT_INFANTRY_MORALE;Casters Morale;;Zauberer – Moral;;;;;;;;;;;x
-LIGHT_INFANTRY_MODIFIER;Casters Modifier;;Zauberer – Disziplin;;;;;;;;;;;x
-CU_LIGHT_INFANTRY;Support Troops;;Unterstützende Infanterie;;;;;;;;;;;x
+LIGHT_INFANTRY_OFFENSIVE_FIRE;Casters Attack;;Zauberer â€“ Angriff;;;;;;;;;;;x
+LIGHT_INFANTRY_DEFENSIVE_FIRE;Casters Defense;;Zauberer â€“ Verteidigung;;;;;;;;;;;x
+LIGHT_INFANTRY_MORALE;Casters Morale;;Zauberer â€“ Moral;;;;;;;;;;;x
+LIGHT_INFANTRY_MODIFIER;Casters Modifier;;Zauberer â€“ Disziplin;;;;;;;;;;;x
+CU_LIGHT_INFANTRY;Support Troops;;UnterstÃ¼tzende Infanterie;;;;;;;;;;;x
 CU_ACTUAL_LIGHT_INFANTRY;Casters;;Zauberer;;;;;;;;;;;x
-large_cavalry;Large Cavalry;;Große Kavallerie;;;;;;;;;;;x
-large_cavalry_offensive;Large Cavalry Attack;;Große Kavallerie – Angriff;;;;;;;;;;;x
-large_cavalry_defensive;Large Cavalry Defense;;Große Kavallerie – Verteidigung;;;;;;;;;;;x
-large_cavalry_morale;Large Cavalry Morale;;Große Kavallerie – Moral;;;;;;;;;;;x
-large_cavalry_modifier;Large Cavalry Modifier;;Große Kavallerie – Disziplin;;;;;;;;;;;x
+large_cavalry;Large Cavalry;;GroÃŸe Kavallerie;;;;;;;;;;;x
+large_cavalry_offensive;Large Cavalry Attack;;GroÃŸe Kavallerie â€“ Angriff;;;;;;;;;;;x
+large_cavalry_defensive;Large Cavalry Defense;;GroÃŸe Kavallerie â€“ Verteidigung;;;;;;;;;;;x
+large_cavalry_morale;Large Cavalry Morale;;GroÃŸe Kavallerie â€“ Moral;;;;;;;;;;;x
+large_cavalry_modifier;Large Cavalry Modifier;;GroÃŸe Kavallerie â€“ Disziplin;;;;;;;;;;;x
 archmage;Archmage;;Erzmagier;;;;;;;;;;;x
-archmage_offensive;Archmage Attack;;Erzmagier – Angriff;;;;;;;;;;;x
-archmage_defensive;Archmage Defense;;Erzmagier – Verteidigung;;;;;;;;;;;x
-archmage_morale;Archmage Morale;;Erzmagier – Moral;;;;;;;;;;;x
-archmage_modifier;Archmage Modifier;;Erzmagier – Disziplin;;;;;;;;;;;x
+archmage_offensive;Archmage Attack;;Erzmagier â€“ Angriff;;;;;;;;;;;x
+archmage_defensive;Archmage Defense;;Erzmagier â€“ Verteidigung;;;;;;;;;;;x
+archmage_morale;Archmage Morale;;Erzmagier â€“ Moral;;;;;;;;;;;x
+archmage_modifier;Archmage Modifier;;Erzmagier â€“ Disziplin;;;;;;;;;;;x
 undead;Undead;;Ghouls;;;;;;;;;;;x
-undead_offensive;Undead Attack;;Ghouls – Angriff;;;;;;;;;;;x
-undead_defensive;Undead Defense;;Ghouls – Verteidigung;;;;;;;;;;;x
-undead_morale;Undead Morale;;Ghouls – Moral;;;;;;;;;;;x
-undead_modifier;Undead Modifier;;Ghouls – Disziplin;;;;;;;;;;;x
+undead_offensive;Undead Attack;;Ghouls â€“ Angriff;;;;;;;;;;;x
+undead_defensive;Undead Defense;;Ghouls â€“ Verteidigung;;;;;;;;;;;x
+undead_morale;Undead Morale;;Ghouls â€“ Moral;;;;;;;;;;;x
+undead_modifier;Undead Modifier;;Ghouls â€“ Disziplin;;;;;;;;;;;x
 war_machines;War Machines;;Kriegsmaschinen;;;;;;;;;;;x
-war_machines_offensive;War Machine Attack;;Kriegsmaschinen – Angriff;;;;;;;;;;;x
-war_machines_defensive;War Machine Defense;;Kriegsmaschinen – Verteidigung;;;;;;;;;;;x
-war_machines_morale;War Machine Morale;;Kriegsmaschinen – Moral;;;;;;;;;;;x
-war_machines_modifier;War Machine Modifier;;Kriegsmaschinen – Disziplin;;;;;;;;;;;x
+war_machines_offensive;War Machine Attack;;Kriegsmaschinen â€“ Angriff;;;;;;;;;;;x
+war_machines_defensive;War Machine Defense;;Kriegsmaschinen â€“ Verteidigung;;;;;;;;;;;x
+war_machines_morale;War Machine Morale;;Kriegsmaschinen â€“ Moral;;;;;;;;;;;x
+war_machines_modifier;War Machine Modifier;;Kriegsmaschinen â€“ Disziplin;;;;;;;;;;;x
 animals;Animals;;Tiere;;;;;;;;;;;x
-animals_offensive;Animals Attack;;Tiere – Angriff;;;;;;;;;;;x
-animals_defensive;Animals Defense;;Tiere – Verteidigung;;;;;;;;;;;x
-animals_morale;Animals Morale;;Tiere – Moral;;;;;;;;;;;x
-animals_modifier;Animals Modifier;;Tiere – Disziplin;;;;;;;;;;;x
+animals_offensive;Animals Attack;;Tiere â€“ Angriff;;;;;;;;;;;x
+animals_defensive;Animals Defense;;Tiere â€“ Verteidigung;;;;;;;;;;;x
+animals_morale;Animals Morale;;Tiere â€“ Moral;;;;;;;;;;;x
+animals_modifier;Animals Modifier;;Tiere â€“ Disziplin;;;;;;;;;;;x
 dragons;Dragons;;Drachen;;;;;;;;;;;x
-dragons_offensive;Dragons Attack;;Drachen – Angriff;;;;;;;;;;;x
-dragons_defensive;Dragons Defense;;Drachen – Verteidigung;;;;;;;;;;;x
-dragons_morale;Dragons Morale;;Drachen – Moral;;;;;;;;;;;x
-dragons_modifier;Dragons Modifier;;Drachen – Disziplin;;;;;;;;;;;x
+dragons_offensive;Dragons Attack;;Drachen â€“ Angriff;;;;;;;;;;;x
+dragons_defensive;Dragons Defense;;Drachen â€“ Verteidigung;;;;;;;;;;;x
+dragons_morale;Dragons Morale;;Drachen â€“ Moral;;;;;;;;;;;x
+dragons_modifier;Dragons Modifier;;Drachen â€“ Disziplin;;;;;;;;;;;x
 golems;Golems;;;;;;;;;;;;;x
 golems_offensive;Golems Attack;;;;;;;;;;;;;x
 golems_defensive;Golems Defense;;;;;;;;;;;;;x
 golems_morale;Golems Morale;;;;;;;;;;;;;x
 golems_modifier;Golems Modifier;;;;;;;;;;;;;x
 ancients;Ancients;;Urtume;;;;;;;;;;;x
-ancients_offensive;Ancients Attack;;Urtume – Angriff;;;;;;;;;;;x
-ancients_defensive;Ancients Defense;;Urtume – Verteidigung;;;;;;;;;;;x
-ancients_morale;Ancients Morale;;Urtume – Moral;;;;;;;;;;;x
-ancients_modifier;Ancients Modifier;;Urtume – Disziplin;;;;;;;;;;;x
+ancients_offensive;Ancients Attack;;Urtume â€“ Angriff;;;;;;;;;;;x
+ancients_defensive;Ancients Defense;;Urtume â€“ Verteidigung;;;;;;;;;;;x
+ancients_morale;Ancients Morale;;Urtume â€“ Moral;;;;;;;;;;;x
+ancients_modifier;Ancients Modifier;;Urtume â€“ Disziplin;;;;;;;;;;;x
 swarm;Swarm;;Schwarm;;;;;;;;;;;x
-swarm_offensive;Swarm Attack;;Schwarm – Angriff;;;;;;;;;;;x
-swarm_defensive;Swarm Defense;;Schwarm – Verteidigung;;;;;;;;;;;x
-swarm_morale;Swarm Morale;;Schwarm – Moral;;;;;;;;;;;x
-swarm_modifier;Swarm Modifier;;Schwarm – Disziplin;;;;;;;;;;;x
+swarm_offensive;Swarm Attack;;Schwarm â€“ Angriff;;;;;;;;;;;x
+swarm_defensive;Swarm Defense;;Schwarm â€“ Verteidigung;;;;;;;;;;;x
+swarm_morale;Swarm Morale;;Schwarm â€“ Moral;;;;;;;;;;;x
+swarm_modifier;Swarm Modifier;;Schwarm â€“ Disziplin;;;;;;;;;;;x
 siege_machines;Siege Machines;;Belagerungsmaschinen;;;;;;;;;;;x
-siege_machines_offensive;Siege Machine Attack;;Belagerungsmaschinen – Angriff;;;;;;;;;;;x
-siege_machines_defensive;Siege Machine Defense;;Belagerungsmaschinen – Verteidigung;;;;;;;;;;;x
-siege_machines_morale;Siege Machine Morale;;Belagerungsmaschinen – Moral;;;;;;;;;;;x
-siege_machines_modifier;Siege Machine Modifier;;Belagerungsmaschinen – Disziplin;;;;;;;;;;;x
+siege_machines_offensive;Siege Machine Attack;;Belagerungsmaschinen â€“ Angriff;;;;;;;;;;;x
+siege_machines_defensive;Siege Machine Defense;;Belagerungsmaschinen â€“ Verteidigung;;;;;;;;;;;x
+siege_machines_morale;Siege Machine Morale;;Belagerungsmaschinen â€“ Moral;;;;;;;;;;;x
+siege_machines_modifier;Siege Machine Modifier;;Belagerungsmaschinen â€“ Disziplin;;;;;;;;;;;x
 thralls;Thralls;;Leibeigene;;;;;;;;;;;x
-thralls_offensive;Thrall Attack;;Leibeigene – Angriff;;;;;;;;;;;x
-thralls_defensive;Thrall Defense;;Leibeigene – Verteidigung;;;;;;;;;;;x
-thralls_morale;Thrall Morale;;Leibeigene – Moral;;;;;;;;;;;x
-thralls_modifier;Thrall Modifier;;Leibeigene – Disziplin;;;;;;;;;;;x
+thralls_offensive;Thrall Attack;;Leibeigene â€“ Angriff;;;;;;;;;;;x
+thralls_defensive;Thrall Defense;;Leibeigene â€“ Verteidigung;;;;;;;;;;;x
+thralls_morale;Thrall Morale;;Leibeigene â€“ Moral;;;;;;;;;;;x
+thralls_modifier;Thrall Modifier;;Leibeigene â€“ Disziplin;;;;;;;;;;;x
 elite_infantry;Elite Infantry;;Eliteinfanterie;;;;;;;;;;;x
-elite_infantry_offensive;Elite Infantry Attack;;Eliteinfanterie – Angriff;;;;;;;;;;;x
-elite_infantry_defensive;Elite Infantry Defense;;Eliteinfanterie – Verteidigung;;;;;;;;;;;x
-elite_infantry_morale;Elite Infantry Morale;;Eliteinfanterie – Moral;;;;;;;;;;;x
-elite_infantry_modifier;Elite Infantry Modifier;;Eliteinfanterie – Disziplin;;;;;;;;;;;x
+elite_infantry_offensive;Elite Infantry Attack;;Eliteinfanterie â€“ Angriff;;;;;;;;;;;x
+elite_infantry_defensive;Elite Infantry Defense;;Eliteinfanterie â€“ Verteidigung;;;;;;;;;;;x
+elite_infantry_morale;Elite Infantry Morale;;Eliteinfanterie â€“ Moral;;;;;;;;;;;x
+elite_infantry_modifier;Elite Infantry Modifier;;Eliteinfanterie â€“ Disziplin;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Tactics;;;;;;;;;;;;;;x
-wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes Geplänkel;;;;;;;;;;;x
-wc_skirmish_tactic;Skirmish;;Geplänkel;;;;;;;;;;;x
+wc_organized_skirmish_tactic;Organized Skirmish;;Organisiertes GeplÃ¤nkel;;;;;;;;;;;x
+wc_skirmish_tactic;Skirmish;;GeplÃ¤nkel;;;;;;;;;;;x
 wc_aerial_raid_tactic;Aerial Raid;;Flugangriff;;;;;;;;;;;x
-wc_aerial_strikes_tactic;Aerial Strikes;;Luftschläge;;;;;;;;;;;x
+wc_aerial_strikes_tactic;Aerial Strikes;;LuftschlÃ¤ge;;;;;;;;;;;x
 wc_volley_tactic;Volley;;Salve;;;;;;;;;;;x
 wc_magic_volley_tactic;Magic Volley;;Magische Salve;;;;;;;;;;;x
 wc_bombardment_tactic;Bombardment;;Bombardement;;;;;;;;;;;x
@@ -132,41 +132,41 @@ wc_charge_tactic;Charge;;Sturmangriff;;;;;;;;;;;x
 wc_crushing_charge_tactic;Crushing Charge;;Vernichtender Sturmangriff;;;;;;;;;;;x
 wc_undefended_charge_on_flank_tactic;Undefended Charge on Flank;;Deckungsloser Sturmangriff auf die Flanke;;;;;;;;;;;x
 wc_spearhead_tactic;Spearhead;;Speerspitze;;;;;;;;;;;x
-wc_advance_tactic;Advance;;Vorrücken;;;;;;;;;;;x
-wc_push_tactic;Push;;Drängen;;;;;;;;;;;x
+wc_advance_tactic;Advance;;VorrÃ¼cken;;;;;;;;;;;x
+wc_push_tactic;Push;;DrÃ¤ngen;;;;;;;;;;;x
 wc_pike_wall_tactic;Pike Wall;;Speerwall;;;;;;;;;;;x
 wc_barrier_tactic;Barrier;;Barriere;;;;;;;;;;;x
-wc_overwhelm_tactic;Overwhelm;;Überwältigen;;;;;;;;;;;x
+wc_overwhelm_tactic;Overwhelm;;ÃœberwÃ¤ltigen;;;;;;;;;;;x
 wc_roundabout_charge_tactic;Roundabout Charge;;Rundum-Sturmangriff;;;;;;;;;;;x
 wc_barrage_tactic;Barrage;;Sperrfeuer;;;;;;;;;;;x
-wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und Kämpfen;;;;;;;;;;;x
-wc_raid_tactic;Raid;;Überfall;;;;;;;;;;;x
-wc_overrun_tactic;Overrun;;Überrollen;;;;;;;;;;;x
+wc_stand_and_fight_tactic;Stand and Fight;;Aufhalten und KÃ¤mpfen;;;;;;;;;;;x
+wc_raid_tactic;Raid;;Ãœberfall;;;;;;;;;;;x
+wc_overrun_tactic;Overrun;;Ãœberrollen;;;;;;;;;;;x
 wc_tank_and_heal_tactic;Tank and Heal;;Aufhalten und Heilen;;;;;;;;;;;x
 wc_trample_tactic;Trample;;Niedertrampeln;;;;;;;;;;;x
-wc_reinforce_tactic;Reinforce;;Verstärken;;;;;;;;;;;x
+wc_reinforce_tactic;Reinforce;;VerstÃ¤rken;;;;;;;;;;;x
 wc_force_back_tactic;Force Back;;Gegenschlag;;;;;;;;;;;x
 wc_swift_volley_tactic;Swift Volley;;Schnelle Salve;;;;;;;;;;;x
 wc_aimed_bombardment_tactic;Aimed Bombardment;;Gezielte Bombardierung;;;;;;;;;;;x
-wc_draw_out_tactic;Draw Out;;Zurückziehen;;;;;;;;;;;x
+wc_draw_out_tactic;Draw Out;;ZurÃ¼ckziehen;;;;;;;;;;;x
 wc_aerial_bombardment_tactic ;Aerial Bombardment;;Luftbombardement;;;;;;;;;;;x
 wc_hedgehog_formation_tactic ;Hedgehog Formation;;Igel-Formation;;;;;;;;;;;x
 wc_entrench_tactic ;Entrench;;Eingraben;;;;;;;;;;;x
 wc_heroic_charge_tactic;Heroic Charge;;Heroischer Sturmangriff;;;;;;;;;;;x
 wc_trample_spearhead_tactic;Trample Spearhead;;Speerspitzen-Trampelangriff;;;;;;;;;;;x
-wc_strengthened_barrier_tactic;Strengthened Barrier;;Verstärkte Barriere;;;;;;;;;;;x
+wc_strengthened_barrier_tactic;Strengthened Barrier;;VerstÃ¤rkte Barriere;;;;;;;;;;;x
 wc_crafty_ambush_tactic;Crafty Ambush;;Raffinierter Hinterhalt;;;;;;;;;;;x
-wc_religious_zeal_tactic;Religious Zeal;;Religiöser Eifer;;;;;;;;;;;x
-wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische Verstärkung;;;;;;;;;;;x
-wc_slow_harassment_tactic;Slow Harassment;;Langsame Übergriffe;;;;;;;;;;;x
+wc_religious_zeal_tactic;Religious Zeal;;ReligiÃ¶ser Eifer;;;;;;;;;;;x
+wc_tactical_reinforce_tactic;Tactical Reinforce;;Taktische VerstÃ¤rkung;;;;;;;;;;;x
+wc_slow_harassment_tactic;Slow Harassment;;Langsame Ãœbergriffe;;;;;;;;;;;x
 wc_unintentional_charge_tactic;Unintentional Charge;;Unbeabsichtigter Sturmangriff;;;;;;;;;;;x
 wc_fire_on_own_troops_tactic;Fire on Own Troops;;Feuer auf eigene Truppen;;;;;;;;;;;x
-wc_outranged_tactic;Outranged;;Außer Reichweite;;;;;;;;;;;x
+wc_outranged_tactic;Outranged;;AuÃŸer Reichweite;;;;;;;;;;;x
 wc_aggressive_defense_tactic;Aggressive Defense;;Aggressive Verteidigung;;;;;;;;;;;x
 wc_outstretched_tactic;Outstretched;;Ausgedehnt;;;;;;;;;;;x
-wc_reckless_charge_tactic;Reckless Charge;;Rücksichtsloser Sturmangriff;;;;;;;;;;;x
-wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch Scharmützler;;;;;;;;;;;x
-wc_hesitate_tactic;Hesitate;;Zögern;;;;;;;;;;;x
+wc_reckless_charge_tactic;Reckless Charge;;RÃ¼cksichtsloser Sturmangriff;;;;;;;;;;;x
+wc_charge_through_skirmishers_tactic;Charge Through Skirmishers;;Sturmangriff durch ScharmÃ¼tzler;;;;;;;;;;;x
+wc_hesitate_tactic;Hesitate;;ZÃ¶gern;;;;;;;;;;;x
 wc_failed_barrier_tactic;Failed Barrier;;Fehlgeschlagene Barriere;;;;;;;;;;;x
 wc_advance_in_the_wrong_direction_tactic;Advance in the Wrong Direction;;Fortschritt in die falsche Richtung;;;;;;;;;;;x
 wc_aerial_melee_tactic;Aerial Melee;;Luftnahkampf;;;;;;;;;;;x
@@ -174,31 +174,31 @@ wc_forest_ambush_tactic;Forest Ambush;;Hinterhalt im Wald;;;;;;;;;;;x
 wc_spellbreak_tactic;Spellbreak;;Zauberbruch;;;;;;;;;;;x
 wc_breaking_charge_tactic;Breaking Charge;;Durchbrechender Sturmangriff;;;;;;;;;;;x
 wc_mountain_entrenchment_tactic;Mountain Entrenchment;;Bergeingrabung;;;;;;;;;;;x
-wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der Wüste;;;;;;;;;;;x
+wc_desert_ambush_tactic;Desert Ambush;;Hinterhalt in der WÃ¼ste;;;;;;;;;;;x
 wc_swarm_charge_tactic;Swarm Charge;;Schwarm-Sturmangriff;;;;;;;;;;;x
 wc_swarm_volley_tactic;Swarm Volley;;Schwarm Salve;;;;;;;;;;;x
-wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Übergriffe;;;;;;;;;;;x
+wc_swarm_harassment_tactic;Swarm Harassment;;Schwarm-Ãœbergriffe;;;;;;;;;;;x
 wc_swarm_encircle_tactic;Swarm Encircle;;Schwarmeinkreisung;;;;;;;;;;;x
-wc_overrun_push_tactic;Overrun Push;;Überrennender Stoß;;;;;;;;;;;x
+wc_overrun_push_tactic;Overrun Push;;Ãœberrennender StoÃŸ;;;;;;;;;;;x
 wc_magic_ambush_ractic;Magic Ambush;;Magischer Hinterhalt;;;;;;;;;;;x
-wc_mountain_raid_tactic;Mountain Raid;;Bergüberfall;;;;;;;;;;;x
+wc_mountain_raid_tactic;Mountain Raid;;BergÃ¼berfall;;;;;;;;;;;x
 wc_water_assault_tactic;Water Assault;;Amphibischer Angriff;;;;;;;;;;;x
-wc_commando_raid_tactic;Commando Raid;;Spezialüberfall;;;;;;;;;;;x
+wc_commando_raid_tactic;Commando Raid;;SpezialÃ¼berfall;;;;;;;;;;;x
 wc_crush_and_trample_tactic;Crush and Trample;;Zerquetschen und zertrampeln;;;;;;;;;;;x
 wc_underground_ambush_ractic;Underground Ambush;;Unterirdischer Hinterhalt;;;;;;;;;;;x
 wc_brutalizing_trample_tactic;Brutalizing Trample;;Brutales Zertrampeln;;;;;;;;;;;x
 wc_tundra_swarm_tactic;Tundra Swarm;;Tundra-Schwarm;;;;;;;;;;;x
 wc_forest_charge_tactic;Forest Charge;;Waldsturmangriff;;;;;;;;;;;x
 wc_heroic_trample_tactic;Heroic Trample;;Heroisches Zertrampeln;;;;;;;;;;;x
-wc_desert_entrenchment_tactic;Desert Entrenchment;;Wüsteneingrabung;;;;;;;;;;;x
+wc_desert_entrenchment_tactic;Desert Entrenchment;;WÃ¼steneingrabung;;;;;;;;;;;x
 wc_winter_ambush_tactic;Winter Ambush;;Hinterhalt im Winter;;;;;;;;;;;x
 wc_aerial_ambush_tactic;Aerial Ambush;;Lufthinterhalt;;;;;;;;;;;x
-wc_undead_overrun_tactic;Undead Overrun;;Untotes Überrennen;;;;;;;;;;;x
+wc_undead_overrun_tactic;Undead Overrun;;Untotes Ãœberrennen;;;;;;;;;;;x
 wc_undead_spearhead_tactic;Under Spearhead;;Unter der Speerspitze;;;;;;;;;;;x
 wc_null_magic_tactic;Null Magic;;Magie aufheben;;;;;;;;;;;x
 wc_undead_ambush_tactic;Undead Ambush;;Untoter Hinterhalt;;;;;;;;;;;x
 wc_blinding_light_charge_tactic;Blinding Light Charge;;Blendende Lichtladung;;;;;;;;;;;x
-wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhöhter Eifer;;;;;;;;;;;x
+wc_loa_enhanced_zeal_tactic;Loa Enhanced Zeal;;Durch Loa erhÃ¶hter Eifer;;;;;;;;;;;x
 wc_ancient_ambush_tactic;Ancient Ambush;;Urtum-Hinterhalt;;;;;;;;;;;x
 wc_taunt_tactic;Taunt;;Spott;;;;;;;;;;;x
 wc_shield_slam_tactic;Shield Slam;;Schildschlag;;;;;;;;;;;x
@@ -206,8 +206,8 @@ wc_thunderclap_tactic;Thunderclap;;Donnerschlag;;;;;;;;;;;x
 wc_cleave_tactic;Cleave;;Spalten;;;;;;;;;;;x
 wc_multishot_tactic;Multishot;;Mehrfachschuss;;;;;;;;;;;x
 wc_explosive_trap_tactic;Explosive Trap;;Sprengfalle;;;;;;;;;;;x
-wc_kill_command_tactic;Kill Command;;Tötungsbefehl;;;;;;;;;;;x
-wc_disengage_tactic;Disengage;;Lösen;;;;;;;;;;;x
+wc_kill_command_tactic;Kill Command;;TÃ¶tungsbefehl;;;;;;;;;;;x
+wc_disengage_tactic;Disengage;;LÃ¶sen;;;;;;;;;;;x
 wc_distract_tactic;Distract;;Ablenken;;;;;;;;;;;x
 wc_evasion_tactic;Evasion;;Ausweichen;;;;;;;;;;;x
 wc_poisoned_volley_tactic;Poisoned Volley;;Vergiftete Salve;;;;;;;;;;;x
@@ -218,14 +218,14 @@ wc_chains_of_ice_tactic;Chains of Ice;;Eisketten;;;;;;;;;;;x
 wc_death_coil_tactic;Death Coil;;Todesspirale;;;;;;;;;;;x
 wc_blight_bombardment_tactic;Blight Bombardment;;Pesthauch-Bombardement;;;;;;;;;;;x
 wc_raise_undead_tactic;Raise Undead;;Erwecke Untote;;;;;;;;;;;x
-wc_empower_undead_tactic;Empower Undead;;Untote verstärken;;;;;;;;;;;x
-wc_cripple_tactic;Cripple;;Verkrüppeln;;;;;;;;;;;x
+wc_empower_undead_tactic;Empower Undead;;Untote verstÃ¤rken;;;;;;;;;;;x
+wc_cripple_tactic;Cripple;;VerkrÃ¼ppeln;;;;;;;;;;;x
 wc_consume_magic_tactic;Consume Magic;;Magie verzehren;;;;;;;;;;;x
-wc_torment_tactic;Torment;;Quälen;;;;;;;;;;;x
+wc_torment_tactic;Torment;;QuÃ¤len;;;;;;;;;;;x
 wc_immolation_tactic;Immolation;;Feuerbrand;;;;;;;;;;;x
 wc_blade_dance_tactic;Blade Dance;;Klingensturm;;;;;;;;;;;x
 wc_entangling_roots_tactic;Entangling Roots;;Wucherwurzeln;;;;;;;;;;;x
-wc_rejuvenate_tactic;Rejuvenate;;Verjüngung;;;;;;;;;;;x
+wc_rejuvenate_tactic;Rejuvenate;;VerjÃ¼ngung;;;;;;;;;;;x
 wc_lunar_strike_tactic;Lunar Strike;;Mondschlag;;;;;;;;;;;x
 wc_starfall_tactic;Starfall;;Sternenregen;;;;;;;;;;;x
 wc_arcane_barrage_tactic;Arcane Barrage;;Arkanes Sperrfeuer;;;;;;;;;;;x
@@ -258,9 +258,9 @@ wc_rain_of_fire_tactic;Rain of Fire;;Feuerregen;;;;;;;;;;;x
 wc_soul_link_tactic;Soul Link;;Seelenverbindung;;;;;;;;;;;x
 elephant_trample_tactic;Trample;;Zertrampeln;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues – Generic;;;;;;;;;;;;;;x
+# Retinues â€“ Generic;;;;;;;;;;;;;;x
 wc_ret_gen_inf;Infantry Division;;Infanteriedivision;;;;;;;;;;;x
-wc_ret_gen_ran;Ranged Battalion;;Fernkämpferbataillon;;;;;;;;;;;x
+wc_ret_gen_ran;Ranged Battalion;;FernkÃ¤mpferbataillon;;;;;;;;;;;x
 wc_ret_gen_cav;Cavalry Squadron;;Reiterstaffel;;;;;;;;;;;x
 wc_ret_gen_cas;Caster Company;;Zauberertrupp;;;;;;;;;;;x
 wc_ret_gen_aer;Aerial Company;;Fliegerstaffel;;;;;;;;;;;x
@@ -268,113 +268,113 @@ wc_ret_gen_van;Vanguard Division;;Vorauskommando;;;;;;;;;;;x
 wc_ret_gen_adv;Adventurers;;Abenteurer;;;;;;;;;;;x
 wc_ret_gen_art;Artillery Company;;Artilleriebatterie;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues – Tribal;;;;;;;;;;;;;;x
+# Retinues â€“ Tribal;;;;;;;;;;;;;;x
 wc_ret_tribe_pure;Tribal Mob;;;;;;;;;;;;;
 wc_ret_tribe_inf;Warriors;;Krieger;;;;;;;;;;;x
-wc_ret_tribe_ran;Hunters;;Jäger;;;;;;;;;;;x
+wc_ret_tribe_ran;Hunters;;JÃ¤ger;;;;;;;;;;;x
 wc_ret_tribe_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_tribe_van;Champions;;Champions;;;;;;;;;;;x
 wc_ret_tribe_cas;Totemists;;Totemisten;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues – Cultural;;;;;;;;;;;;;;x
+# Retinues â€“ Cultural;;;;;;;;;;;;;;x
 wc_ret_cul_qiraji;Silithud Swarm;;Silithud-Schwarm;;;;;;;;;;;x
 wc_ret_cul_nerubian;Spiderlords;;Spinnenlords;;;;;;;;;;;x
-wc_ret_cul_centaur;Outrunners;;Vorläufer;;;;;;;;;;;x
+wc_ret_cul_centaur;Outrunners;;VorlÃ¤ufer;;;;;;;;;;;x
 wc_ret_cul_eredar;Chaosborn;;Chaosgeborene;;;;;;;;;;;x
-wc_ret_cul_draenei;Peacekeepers;;Friedenswächterinnen;;;;;;;;;;;x
+wc_ret_cul_draenei;Peacekeepers;;FriedenswÃ¤chterinnen;;;;;;;;;;;x
 wc_ret_cul_dragon;Drakes;;Drachen;;;;;;;;;;;x
 wc_ret_cul_dryad;Grove Host;;Heerschar des Waldes;;;;;;;;;;;x
-wc_ret_cul_bronzebeard;Mountaineers;;Bergführer;;;;;;;;;;;x
+wc_ret_cul_bronzebeard;Mountaineers;;BergfÃ¼hrer;;;;;;;;;;;x
 wc_ret_cul_wildhammer;Gryphon Knights;;Greifenritter;;;;;;;;;;;x
 wc_ret_cul_darkiron;Dragoons;;Dragoner;;;;;;;;;;;x
 wc_ret_cul_frostborn;Axemasters;;Axtmeister;;;;;;;;;;;x
 wc_ret_cul_furbolg;Ursas;;Ursas;;;;;;;;;;;x
 wc_ret_cul_gnoll;Brutes;;Rohlinge;;;;;;;;;;;x
-wc_ret_cul_wolvar;Tundra Hunters;;Tundra-Jäger;;;;;;;;;;;x
+wc_ret_cul_wolvar;Tundra Hunters;;Tundra-JÃ¤ger;;;;;;;;;;;x
 wc_ret_cul_gnome;Commandos;;Kommandotruppen;;;;;;;;;;;x
 wc_ret_cul_goblin;Shredders;;Schredder;;;;;;;;;;;x
 wc_ret_cul_harpy;Roguefeathers;;Schurkenfedern;;;;;;;;;;;x
-wc_ret_cul_highelf;Rangers;;Waldläufer;;;;;;;;;;;x
+wc_ret_cul_highelf;Rangers;;WaldlÃ¤ufer;;;;;;;;;;;x
 wc_ret_cul_bloodelf;Spellbreakers;;Zauberbrecher;;;;;;;;;;;x
 wc_ret_cul_hozen;Pounders;;Stampfer;;;;;;;;;;;x
 wc_ret_cul_lordaeron;Knights;;Ritter;;;;;;;;;;;x
-wc_ret_cul_gilnean;Greyguard;;Grauwächter;;;;;;;;;;;x
-wc_ret_cul_arathor;Troll Hunters;;Trolljäger;;;;;;;;;;;x
+wc_ret_cul_gilnean;Greyguard;;GrauwÃ¤chter;;;;;;;;;;;x
+wc_ret_cul_arathor;Troll Hunters;;TrolljÃ¤ger;;;;;;;;;;;x
 wc_ret_cul_azeroth;7th Legion;;7. Legion;;;;;;;;;;;x
 wc_ret_cul_dalaran;Archmages;;Erzmagier;;;;;;;;;;;x
-wc_ret_cul_alterac;Mountain Rangers;;Gebirgsjäger;;;;;;;;;;;x
+wc_ret_cul_alterac;Mountain Rangers;;GebirgsjÃ¤ger;;;;;;;;;;;x
 wc_ret_cul_tiras;Marines;;Marinesoldaten;;;;;;;;;;;x
-wc_ret_cul_northern;Huntsmen;;Jäger;;;;;;;;;;;x
+wc_ret_cul_northern;Huntsmen;;JÃ¤ger;;;;;;;;;;;x
 wc_ret_cul_pirate;Corsairs;;Korsaren;;;;;;;;;;;x
 wc_ret_cul_kobold;Candleholders;;Kerzenhalter;;;;;;;;;;;x
 wc_ret_cul_snobold;Tundra Guard;;Tundra-Wache;;;;;;;;;;;x
 wc_ret_cul_magnataur;Crushers;;Brecher;;;;;;;;;;;x
-wc_ret_cul_murloc;Tide Hunters;;Gezeitenjäger;;;;;;;;;;;x
+wc_ret_cul_murloc;Tide Hunters;;GezeitenjÃ¤ger;;;;;;;;;;;x
 wc_ret_cul_gorloc;Oracles;;Orakel;;;;;;;;;;;x
-wc_ret_cul_naga;Royal Guard;;Königliche Wache;;;;;;;;;;;x
-wc_ret_cul_nightelf;Sentinels;;Wächter;;;;;;;;;;;x
-wc_ret_cul_highborne;Archconjurers;;Erzbeschwörer;;;;;;;;;;;x
+wc_ret_cul_naga;Royal Guard;;KÃ¶nigliche Wache;;;;;;;;;;;x
+wc_ret_cul_nightelf;Sentinels;;WÃ¤chter;;;;;;;;;;;x
+wc_ret_cul_highborne;Archconjurers;;ErzbeschwÃ¶rer;;;;;;;;;;;x
 wc_ret_cul_ogre;Maulers;;Zerfleischer;;;;;;;;;;;x
 wc_ret_cul_warsong;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_cul_shadowm;Darkcasters;;Dunkelwirker;;;;;;;;;;;x
 wc_ret_cul_blhollow;Savages;;Wilde;;;;;;;;;;;x
-wc_ret_cul_blackrock;Demolishers;;Zerstörer;;;;;;;;;;;x
+wc_ret_cul_blackrock;Demolishers;;ZerstÃ¶rer;;;;;;;;;;;x
 wc_ret_cul_bblade;Blademasters;;Klingenmeister;;;;;;;;;;;x
 wc_ret_cul_storeave;Warlocks;;Hexenmeister;;;;;;;;;;;x
 wc_ret_cul_thunlord;Beastmasters;;Bestienmeister;;;;;;;;;;;x
 wc_ret_cul_bonechew;Cannibals;;Kannibalen;;;;;;;;;;;x
 wc_ret_cul_laughskull;Enforcers;;Vollstrecker;;;;;;;;;;;x
 wc_ret_cul_shathand;Gladiators;;Gladiatoren;;;;;;;;;;;x
-wc_ret_cul_frostwolf;Raiders;;Räuber;;;;;;;;;;;x
+wc_ret_cul_frostwolf;Raiders;;RÃ¤uber;;;;;;;;;;;x
 wc_ret_cul_twilhammer;Necrolytes;;Nekrolyten;;;;;;;;;;;x
 wc_ret_cul_dragonmaw;Dragon Riders;;Drachenreiter;;;;;;;;;;;x
 wc_ret_cul_pygmy;Stronglegs;;Starkbeine;;;;;;;;;;;x
 wc_ret_cul_quillboat;Thornguard;;Dornenwache;;;;;;;;;;;x
-wc_ret_cul_satyr;Hellcallers;;Höllenrufer;;;;;;;;;;;x
-wc_ret_cul_sethrak;Desert Raiders;;Wüsten-Räuber;;;;;;;;;;;x
+wc_ret_cul_satyr;Hellcallers;;HÃ¶llenrufer;;;;;;;;;;;x
+wc_ret_cul_sethrak;Desert Raiders;;WÃ¼sten-RÃ¤uber;;;;;;;;;;;x
 wc_ret_cul_tauren;Braves;;Tapfere;;;;;;;;;;;x
 wc_ret_cul_gurubashi;Razzashi Cavalry;;Razzashi Kavallerie;;;;;;;;;;;x
-wc_ret_cul_amani;Guardians;;Wächter;;;;;;;;;;;x
+wc_ret_cul_amani;Guardians;;WÃ¤chter;;;;;;;;;;;x
 wc_ret_cul_zandalari;Warguard;;Kriegsgarde;;;;;;;;;;;x
 wc_ret_cul_drakkari;Lancers;;Lanzenreiter;;;;;;;;;;;x
 wc_ret_cul_darktroll;Trappers;;Fallensteller;;;;;;;;;;;x
-wc_ret_cul_farraki;Assassins;;Attentäter;;;;;;;;;;;x
-wc_ret_cul_bloodtroll;War Mothers;;Kriegsmütter;;;;;;;;;;;x
-we_ret_cul_tuskarr;Turtle Cossacks;;Schildkrötenkosaken;;;;;;;;;;;x
+wc_ret_cul_farraki;Assassins;;AttentÃ¤ter;;;;;;;;;;;x
+wc_ret_cul_bloodtroll;War Mothers;;KriegsmÃ¼tter;;;;;;;;;;;x
+we_ret_cul_tuskarr;Turtle Cossacks;;SchildkrÃ¶tenkosaken;;;;;;;;;;;x
 wc_ret_cul_vrykul;Thanes;;Thanen;;;;;;;;;;;x
-wc_ret_cul_vulpera;Merchant Gunner;;Handelsschützen;;;;;;;;;;;x
+wc_ret_cul_vulpera;Merchant Gunner;;HandelsschÃ¼tzen;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues – Religious;;;;;;;;;;;;;;x
+# Retinues â€“ Religious;;;;;;;;;;;;;;x
 wc_ret_rel_scourge;Undead Swarm;;Untoter Schwarm;;;;;;;;;;;x
-wc_ret_rel_scourge2;Frost Wyrms;;Frost-Würmer;;;;;;;;;;;x
+wc_ret_rel_scourge2;Frost Wyrms;;Frost-WÃ¼rmer;;;;;;;;;;;x
 wc_ret_rel_scourge3;Flesh Titans;;Fleisch-Titanen;;;;;;;;;;;x
 wc_ret_rel_scourge4;Death Knights;;Todesritter;;;;;;;;;;;x
 wc_ret_rel_shaytar;Mindless Slaves;;Gedankenlose Sklaven;;;;;;;;;;;x
 wc_ret_rel_shaytar2;Cultists;;Kultisten;;;;;;;;;;;x
 wc_ret_rel_shaytar3;Faceless Reavers;;Gesichtslose Peiniger;;;;;;;;;;;x
 wc_ret_rel_shaytar4;Mutants;;Mutanten;;;;;;;;;;;x
-wc_ret_rel_legion;Lesser Demons;;Niedere Dämonen;;;;;;;;;;;x
-wc_ret_rel_legion2;Greater Demons;;Höhere Dämonen;;;;;;;;;;;x
+wc_ret_rel_legion;Lesser Demons;;Niedere DÃ¤monen;;;;;;;;;;;x
+wc_ret_rel_legion2;Greater Demons;;HÃ¶here DÃ¤monen;;;;;;;;;;;x
 wc_ret_rel_legion3;Fel Reavers;;Fel-Peiniger;;;;;;;;;;;x
-wc_ret_rel_legion4;Doomguard;;Unheilshüter;;;;;;;;;;;x
+wc_ret_rel_legion4;Doomguard;;UnheilshÃ¼ter;;;;;;;;;;;x
 wc_ret_rel_holylight;Paladins;;Paladine;;;;;;;;;;;x
 wc_ret_rel_cultofloa;Loa Host;;Loa-Heerschar;;;;;;;;;;;x
 wc_ret_rel_cultofloa2;Avatars;;Avatare;;;;;;;;;;;x
-wc_ret_rel_illidari;Demonhunters;;Dämonenjäger;;;;;;;;;;;x
+wc_ret_rel_illidari;Demonhunters;;DÃ¤monenjÃ¤ger;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion;Animal Host;;Tierische Heerschar;;;;;;;;;;;x
 wc_ret_rel_kaldoreireligion2;Ancients;;Urtume;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
-# Retinues – Nomadic;;;;;;;;;;;;;;x
-wc_ret_horde_ani;Raiders;;Räuber;;;;;;;;;;;x
+# Retinues â€“ Nomadic;;;;;;;;;;;;;;x
+wc_ret_horde_ani;Raiders;;RÃ¤uber;;;;;;;;;;;x
 wc_ret_horde_cav;Outriders;;Vorreiter;;;;;;;;;;;x
 wc_ret_horde_ran;Marauders;;Marodeure;;;;;;;;;;;x
-wc_ret_horde_cas;Windchasers;;Windjäger;;;;;;;;;;;x
+wc_ret_horde_cas;Windchasers;;WindjÃ¤ger;;;;;;;;;;;x
 wc_ret_horde_lrg;Battle Lords;;Kampfherren;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 #Phase Descriptions;;;;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W and §Y[GetLightCavalryName]§W excel in the §YPursue Phase§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fügt Verluste zu.\n§Y[GetKnightsName]§W, §Y[GetHorseArchersName]§W, §Y[GetDragonsName]§W und §Y[GetLightCavalryName]§W glänzen in der §YPVerfolgungsphase§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W and §Y[GetHorseArchersName]§W excel in the §YSkirmish Phase§W!;;In der Scharmützelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\n§Y[GetActualLightInfantryName]§W, §Y[GetArchersName]§W, §Y[GetArchmageName]§W, §Y[GetSiegeMachinesName]§W und §Y[GetHorseArchersName]§W glänzen in der §YScharmützelphase§W!;;;;;;;;;;;x
-COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W excel in the §YMelee Phase§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstört wird oder flüchtet.\n§Y[GetActualHeavyInfantryName]§W, §Y[GetPikemenName]§W, §Y[GetLightCavalryName]§W, §Y[GetLargeCavalryName]§W, §Y[GetUndeadName]§W, §Y[GetWarMachinesName]§W, §Y[GetAnimalsName]§W, §Y[GetEliteInfantryName]§W, §Y[GetSwarmName]§W, §Y[GetThrallsName]§W glänzen in der §YNahkampfphase§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_PURSUE;In the Pursue phase, one of the armies has routed and the other one is chasing them down.\nÂ§Y[GetKnightsName]Â§W, Â§Y[GetHorseArchersName]Â§W, Â§Y[GetDragonsName]Â§W and Â§Y[GetLightCavalryName]Â§W excel in the Â§YPursue PhaseÂ§W!;;In der Verfolgungsphase ist eine der Armeen geflohen und die andere verfolgt sie und fÃ¼gt Verluste zu.\nÂ§Y[GetKnightsName]Â§W, Â§Y[GetHorseArchersName]Â§W, Â§Y[GetDragonsName]Â§W und Â§Y[GetLightCavalryName]Â§W glÃ¤nzen in der Â§YPVerfolgungsphaseÂ§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_SKIRMISH;In the Skirmish phase, both armies will stay at a distance.\nÂ§Y[GetActualLightInfantryName]Â§W, Â§Y[GetArchersName]Â§W, Â§Y[GetArchmageName]Â§W, Â§Y[GetSiegeMachinesName]Â§W and Â§Y[GetHorseArchersName]Â§W excel in the Â§YSkirmish PhaseÂ§W!;;In der ScharmÃ¼tzelphase bleiben beide Armeen auf Distanz und greifen mit Fernwaffen und Magie an.\nÂ§Y[GetActualLightInfantryName]Â§W, Â§Y[GetArchersName]Â§W, Â§Y[GetArchmageName]Â§W, Â§Y[GetSiegeMachinesName]Â§W und Â§Y[GetHorseArchersName]Â§W glÃ¤nzen in der Â§YScharmÃ¼tzelphaseÂ§W!;;;;;;;;;;;x
+COMBATVIEW_PHASE_DESC_MELEE;In the Melee phase, both armies are locked in close combat.\nÂ§Y[GetActualHeavyInfantryName]Â§W, Â§Y[GetPikemenName]Â§W, Â§Y[GetLightCavalryName]Â§W, Â§Y[GetLargeCavalryName]Â§W, Â§Y[GetUndeadName]Â§W, Â§Y[GetWarMachinesName]Â§W, Â§Y[GetAnimalsName]Â§W, Â§Y[GetEliteInfantryName]Â§W, Â§Y[GetSwarmName]Â§W, Â§Y[GetThrallsName]Â§W excel in the Â§YMelee PhaseÂ§W!;;In der Nahkampfphase sind beide Armeen im Nahkampf gebunden, bis eine zerstÃ¶rt wird oder flÃ¼chtet.\nÂ§Y[GetActualHeavyInfantryName]Â§W, Â§Y[GetPikemenName]Â§W, Â§Y[GetLightCavalryName]Â§W, Â§Y[GetLargeCavalryName]Â§W, Â§Y[GetUndeadName]Â§W, Â§Y[GetWarMachinesName]Â§W, Â§Y[GetAnimalsName]Â§W, Â§Y[GetEliteInfantryName]Â§W, Â§Y[GetSwarmName]Â§W, Â§Y[GetThrallsName]Â§W glÃ¤nzen in der Â§YNahkampfphaseÂ§W!;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x


### PR DESCRIPTION
Changelog:
- Skirmish Techniques and Melee Techniques are back.
- Balanced the first 4 technologies in such way that each of them gives buff to 3 basic units and their special units:
  - Frontline Troops give defensive and moral buff to Casters, Infantry and Ranged Infantry.
  - Assault Troops give defensive and moral buff to Large Infantry, Cavalry and Aerial Infantry.
  - Skirmish Techniques give offensive buff to Casters, Aerial Infantry and Ranged Infantry.
  - Melee Techniques give offensive buff to Infantry, Large Infantry and Cavalry.
- There's a few exceptions:
  - Siege Machines and War Machines get all buffs from Military Engineering.
  - Horse Archers get offensive buff from Skirmish Techniques instead of Melee Techniques.