### PR TITLE
Teron Gorefiend DK second bookmark

### DIFF
--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -458,7 +458,7 @@
 			society_rank_up = 2
 		}
 	}
-	603.1.1={
+	588.1.1={
 		remove_trait = class_warlock_5
 		remove_trait = creature_orc
 		add_trait = creature_human
@@ -594,6 +594,16 @@
 			leave_society = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
+		}
+	}
+	588.1.1={
+		remove_trait = class_warlock_5
+		remove_trait = creature_orc
+		add_trait = creature_human
+		add_trait = being_undead
+		add_trait = class_death_knight_5
+		effect = {
+			set_graphical_culture = human_undead
 		}
 	}
 	591.10.6={ death=yes }

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -458,6 +458,18 @@
 			society_rank_up = 2
 		}
 	}
+	603.1.1={
+		remove_trait = class_warlock_5
+		remove_trait = creature_orc
+		add_trait = creature_human
+		add_trait = being_undead
+		add_trait = class_death_knight_5
+		effect = {
+			set_graphical_culture = human_undead
+			set_name = Teron
+			dynasty = 2352	# Gorefiend
+		}
+	}
 	609.2.19={ death=yes }
 }
 


### PR DESCRIPTION
This makes sure that in the second bookmark Teron'gor is properly Teron Gorefiend (a human) and a DK.

The class rank (Death Knight V) was taken from what is assigned to him during a normal playthrough. If this needs adjusting feel free to let me know.

This PR should fix #859.