### PR TITLE
Fix Highborne provinces history (on reload)

### DIFF
--- a/history/titles/c_avalune.txt
+++ b/history/titles/c_avalune.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330000
 	liege=d_eldrethalas
 }

--- a/history/titles/c_dumont.txt
+++ b/history/titles/c_dumont.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330000
 	liege=d_eldrethalas
 }

--- a/history/titles/c_eldrethalas.txt
+++ b/history/titles/c_eldrethalas.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330000
 	liege=d_eldrethalas
 }

--- a/history/titles/c_elunar.txt
+++ b/history/titles/c_elunar.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330001
 	liege=d_eldrethalas
 }

--- a/history/titles/c_estulan.txt
+++ b/history/titles/c_estulan.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330001
 	liege=d_eldrethalas
 }

--- a/history/titles/c_oneiros.txt
+++ b/history/titles/c_oneiros.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330001
 	liege=d_eldrethalas
 }

--- a/history/titles/c_warpwood.txt
+++ b/history/titles/c_warpwood.txt
@@ -1,5 +1,7 @@
 1.1.1={
 	law = succ_primogeniture
+}
+20.1.1={
 	holder=330000
 	liege=d_eldrethalas
 }

--- a/history/titles/d_eldrethalas.txt
+++ b/history/titles/d_eldrethalas.txt
@@ -3,5 +3,7 @@
 	law = succ_primogeniture
 	law = centralization_2
 	government = feudal_government
+}
+20.1.1={
 	holder=330000
 }


### PR DESCRIPTION
This PR should fix #779.

Turns out all Highborne provinces/titles had this issue (possible others have it too, but I only checked the Highborne ones).

Apparently placing a `holder` on the `1.1.1` makes the history go blank on save reloads. So I checked other immortal(-ish) rulers like Malfurion, Cenarius, etc.. and noticed their `holder` moment is set at `20.1.1`.

Changing the `holder` line to go in another date, in this case `20.1.1` (if you prefer another date, let me know.. Just not `1.1.1`), fixed the issue after a save reload as seen in the screenshot below.

![image](https://user-images.githubusercontent.com/439655/67193803-30ef3c00-f3f6-11e9-9158-158d180513ea.png)
