### PR TITLE
Adventure Rebalance

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -1095,15 +1095,6 @@ on_five_year_pulse = {
 	
 	random_events = {
 		# Warcraft
-		small_invasions = {
-			delay = 25
-			75 = 0
-			
-			15 = WCWAR.705 		# Spawns ravager group
-			10 = WCDRU.350		# Creates pack leader and pick province
-		}
-		
-		# Warcraft
 		120 = WCUND.150		# Undead character rots
 		30 = WCORD.9000		# The Order asks permission to build a castle on your land
 
@@ -1268,6 +1259,15 @@ on_decade_pulse = {
 	}
 	
 	random_events = {
+		# Warcraft
+		small_invasions = {
+			delay = 25
+			84 = 0
+			
+			12 = WCWAR.705 		# Spawns ravager group						# About 8-16 ravagers in 10 years
+			4 = WCDRU.350		# Creates pack leader and pick province		# About 2-4 packs in 10 years
+		}
+		
 		# Warcraft
 		5 = WCVRK.10
 		50 = WCRAC.300 #Adds Ancients seed

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -1264,8 +1264,8 @@ on_decade_pulse = {
 			delay = 25
 			84 = 0
 			
-			12 = WCWAR.705 		# Spawns ravager group						# About 8-16 ravagers in 10 years
-			4 = WCDRU.350		# Creates pack leader and pick province		# About 2-4 packs in 10 years
+			12 = WCWAR.705 		# Spawns ravager group						# About 10 ravagers in 10 years
+			4 = WCDRU.350		# Creates pack leader and pick province		# About 2 packs in 10 years
 		}
 		
 		# Warcraft

--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -720,6 +720,17 @@ is_aggressive_religion_trigger = {
 		religion_group = vrykul_religion_group
 	}
 }
+like_raiding_adventure_triggger = {
+	OR = {
+		culture = pirate_culture
+		
+		evil_public_religion_trigger = yes
+		religion = orcish_fel
+		religion_group = elemental_lords_group
+		religion_group = primitive_group
+		religion_group = vrykul_religion_group
+	}
+}
 
 evil_true_religion_trigger = {
 	custom_tooltip = {

--- a/events/hl_raiding_adventurers_events.txt
+++ b/events/hl_raiding_adventurers_events.txt
@@ -74,19 +74,16 @@ character_event = {
 
 		# Warcraft
 		OR = {
-			# AND = {
-				# any_liege = {
-					# government = nomadic_government
-				# }
-				# culture_group = altaic
-			# }
-			# religion = norse_pagan
-			# religion = norse_pagan_reformed
+			# Warcraft
+			like_raiding_adventure_triggger = yes
+
+			# Warcraft
+
 			AND = {
 				trait = ambitious
-				# martial = 15
-				# diplomacy = 12
-				# health = 4
+				martial = 15
+				diplomacy = 12
+				health = 4
 				NOR = {
 					trait = craven
 					trait = content
@@ -97,6 +94,8 @@ character_event = {
 							is_landed = yes
 						}
 					}
+
+					# Warcraft
 					# NAND = {
 						# uses_decadence = yes
 						# num_of_dynasty_members = 3
@@ -147,8 +146,10 @@ character_event = {
 			}
 		}
 		
-		# Warcraft
 		OR = {
+			# Warcraft
+			has_character_flag = wc_raiding_adventurer_flag
+
 			father_even_if_dead = {
 				OR = {
 					primary_title = { higher_tier_than = BARON }
@@ -171,12 +172,11 @@ character_event = {
 					}
 				}
 			}
-			has_character_flag = wc_raiding_adventurer_flag
 		}
 	}
 	
 	mean_time_to_happen = {
-		years = 30
+		years = 300				# About 2-4 adventures in 10 years like in vanilla
 		modifier = {
 			factor = 0.5
 			trait = ambitious

--- a/events/hl_raiding_adventurers_events.txt
+++ b/events/hl_raiding_adventurers_events.txt
@@ -176,7 +176,7 @@ character_event = {
 	}
 	
 	mean_time_to_happen = {
-		years = 300				# About 2-4 adventures in 10 years like in vanilla
+		years = 300				# About 6 adventures in 10 years during first 50 years, about 29 in 50-150 ingame years
 		modifier = {
 			factor = 0.5
 			trait = ambitious

--- a/events/wc_druidic_events.txt
+++ b/events/wc_druidic_events.txt
@@ -397,11 +397,13 @@ character_event = {
 		}
 		
 		any_realm_province = {
-			num_of_settlements = 1
 			OR = {
 				terrain = forest
 				terrain = woods
 			}
+			num_of_settlements = 1
+			is_occupied = no
+			holder_scope = { is_nomadic = no }
 		}
 	}
 	
@@ -418,11 +420,13 @@ character_event = {
 	immediate = {
 		random_realm_province = {
 			limit = {
-				num_of_settlements = 1
 				OR = {
 					terrain = forest
 					terrain = woods
 				}
+				num_of_settlements = 1
+				is_occupied = no
+				holder_scope = { is_nomadic = no }
 			}
 			preferred_limit = {
 				is_susceptible_to_worgen_curse_province_trigger = yes
@@ -487,6 +491,9 @@ character_event = {
 		wealth = 100
 		prestige = 500
 		piety = 250
+		
+		# Counts
+		change_variable = { which = global_worgen_pack_spawn value = 1 }
 
 		# Create some decent commander characters
 		spawn_great_commander_effect = yes

--- a/events/wc_fel_events.txt
+++ b/events/wc_fel_events.txt
@@ -1597,6 +1597,8 @@ narrative_event = {
 			}
 			10 = {
 				trigger = {
+					ai = no
+					
 					NOT = { trait = being_demon }
 					evil_true_religion_trigger = no
 					evil_public_religion_trigger = no
@@ -1620,10 +1622,6 @@ narrative_event = {
 					trait = brave
 					trait = deceitful
 					trait = cruel
-				}
-				modifier = {	# More small demon invasions
-					factor = 100
-					ai = yes
 				}
 				modifier = {
 					factor = 100
@@ -1653,10 +1651,6 @@ narrative_event = {
 					trait = deceitful
 					trait = cruel
 					trait = erudite
-				}
-				modifier = {	# More small demon invasions
-					factor = 100
-					ai = yes
 				}
 			}
 

--- a/events/wc_war_events.txt
+++ b/events/wc_war_events.txt
@@ -527,10 +527,8 @@ character_event = {
 			
 			random_list = {
 				# Naga
-				50 = {
+				100 = {
 					trigger = {
-						NOT = { religion = old_gods_worship }
-						NOT = { culture_group = naga_group }
 						holder_scope = {
 							NOT = { religion = old_gods_worship }
 							NOT = { culture_group = naga_group }
@@ -585,7 +583,6 @@ character_event = {
 				# Male kvaldir
 				50 = {
 					trigger = {
-						NOT = { religion = helya }
 						holder_scope = {
 							NOT = { religion = helya }
 							top_liege = {
@@ -613,7 +610,6 @@ character_event = {
 				# Male murloc
 				50 = {
 					trigger = {
-						NOT = { culture_group = murloc_group }
 						holder_scope = {
 							NOT = { culture_group = murloc_group }
 							top_liege = {
@@ -657,10 +653,9 @@ character_event = {
 					}
 				}
 			}
-			
-			event_target:target_ravager = {
-				character_event = { id = WCWAR.707 }
-			}
+		}
+		event_target:target_ravager = {
+			character_event = { id = WCWAR.707 }
 		}
 	}
 }
@@ -692,6 +687,9 @@ character_event = {
 		wealth = 500
 		prestige = 500
 		piety = 250
+		
+		# Counts
+		change_variable = { which = global_sea_invader_spawn value = 1 }
 
 		# Create some decent commander characters
 		spawn_great_commander_effect = yes


### PR DESCRIPTION
# Changelog:
- Balanced chance of raiding adventure spawn on vanilla (about 6 adventures in 10 years during first 50 ingame years, about 29 in 50-150 ingame years).
**_Note for Testers:_** Type in console `print_global_variables` to see `global_raiding_adventurer_spawn_by_courtier_MTTH` (number of spawned raiding adventures).
- Decreased chance of worgen pack spawn (about 2 packs in 10 years).
_**Note for Testers:**_ Type in console `print_global_variables` to see `global_worgen_pack_spawn` (number of spawned worgen packs).
- Decreased chance of sea ravager spawn (about 10 ravagers in 10 years).
**_Note for Testers:_** Type in console `print_global_variables` to see `global_sea_invader_spawn` (number of spawned sea ravagers).
- Among all the other sea ravagers, the naga are more likely to spawn after their resurfacing.
# Secret Changelog:
- Only players can get event to spawn annihilan adventurer. This should make adventures more balanceable.