### PR TITLE
20th Bug Crusade

### DIFF
--- a/common/laws/succession_laws.txt
+++ b/common/laws/succession_laws.txt
@@ -1977,6 +1977,16 @@ gender_laws = {
 				}
 			}
 			
+			# Warcraft
+			modifier = {
+				factor = 0
+				holder_scope = { is_matriarchal_trigger = yes }
+			}
+			modifier = {
+				factor = 0
+				holder_scope = { is_gender_equal_trigger = yes }
+			}
+			
 			modifier = {
 				factor = 100
 				holder_scope = {

--- a/common/scripted_triggers/wc_class_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_class_scripted_triggers.txt
@@ -106,83 +106,107 @@ is_combined_class_trigger = {
 }
 
 # Used in conditions of physical abilities
-is_1_2_physical_class_trigger = {
+has_1_2_physical_class_or_higher_trigger = {
 	custom_tooltip = {
-		text = is_1_2_physical_class_trigger_tooltip
+		text = has_1_2_physical_class_or_higher_trigger_tooltip
 		hidden_tooltip = {
 			OR = {
-				trait = class_hunter_1
-				trait = class_hunter_2
-				trait = class_warrior_1
-				trait = class_warrior_2
-				trait = class_rogue_1
-				trait = class_rogue_2
-				is_3_4_physical_class_trigger = yes
+				is_1_2_physical_class_trigger = yes
+				has_3_4_physical_class_or_higher_trigger = yes
 			}
 		}
+	}
+}
+has_3_4_physical_class_or_higher_trigger = {
+	custom_tooltip = {
+		text = has_3_4_physical_class_or_higher_trigger_tooltip
+		hidden_tooltip = {
+			OR = {
+				is_3_4_physical_class_trigger = yes
+				has_5_6_physical_class_or_higher_trigger = yes
+			}
+		}
+	}
+}
+has_5_6_physical_class_or_higher_trigger = {
+	custom_tooltip = {
+		text = has_5_6_physical_class_or_higher_trigger_tooltip
+		hidden_tooltip = {
+			OR = {
+				is_5_6_physical_class_trigger = yes
+				has_7_8_physical_class_or_higher_trigger = yes
+			}
+		}
+	}
+}
+has_7_8_physical_class_or_higher_trigger = {
+	custom_tooltip = {
+		text = has_7_8_physical_class_or_higher_trigger_tooltip
+		hidden_tooltip = {
+			OR = {
+				is_7_8_physical_class_trigger = yes
+				has_9_10_physical_class_trigger = yes
+			}
+		}
+	}
+}
+has_9_10_physical_class_trigger = {
+	custom_tooltip = {
+		text = has_9_10_physical_class_trigger_tooltip
+		hidden_tooltip = {
+			is_9_10_physical_class_trigger = yes
+		}
+	}
+}
+# Check your physical class level
+is_1_2_physical_class_trigger = {
+	OR = {
+		trait = class_hunter_1
+		trait = class_hunter_2
+		trait = class_warrior_1
+		trait = class_warrior_2
+		trait = class_rogue_1
+		trait = class_rogue_2
 	}
 }
 is_3_4_physical_class_trigger = {
-	custom_tooltip = {
-		text = is_3_4_physical_class_trigger_tooltip
-		hidden_tooltip = {
-			OR = {
-				trait = class_hunter_3
-				trait = class_hunter_4
-				trait = class_warrior_3
-				trait = class_warrior_4
-				trait = class_rogue_3
-				trait = class_rogue_4
-				is_5_6_physical_class_trigger = yes
-			}
-		}
+	OR = {
+		trait = class_hunter_3
+		trait = class_hunter_4
+		trait = class_warrior_3
+		trait = class_warrior_4
+		trait = class_rogue_3
+		trait = class_rogue_4
 	}
 }
 is_5_6_physical_class_trigger = {
-	custom_tooltip = {
-		text = is_5_6_physical_class_trigger_tooltip
-		hidden_tooltip = {
-			OR = {
-				trait = class_hunter_5
-				trait = class_hunter_6
-				trait = class_warrior_5
-				trait = class_warrior_6
-				trait = class_rogue_5
-				trait = class_rogue_6
-				is_7_8_physical_class_trigger = yes
-			}
-		}
+	OR = {
+		trait = class_hunter_5
+		trait = class_hunter_6
+		trait = class_warrior_5
+		trait = class_warrior_6
+		trait = class_rogue_5
+		trait = class_rogue_6
 	}
 }
 is_7_8_physical_class_trigger = {
-	custom_tooltip = {
-		text = is_7_8_physical_class_trigger_tooltip
-		hidden_tooltip = {
-			OR = {
-				trait = class_hunter_7
-				trait = class_hunter_8
-				trait = class_warrior_7
-				trait = class_warrior_8
-				trait = class_rogue_7
-				trait = class_rogue_8
-				is_9_10_physical_class_trigger = yes
-			}
-		}
+	OR = {
+		trait = class_hunter_7
+		trait = class_hunter_8
+		trait = class_warrior_7
+		trait = class_warrior_8
+		trait = class_rogue_7
+		trait = class_rogue_8
 	}
 }
 is_9_10_physical_class_trigger = {
-	custom_tooltip = {
-		text = is_9_10_physical_class_trigger_tooltip
-		hidden_tooltip = {
-			OR = {
-				trait = class_hunter_9
-				trait = class_hunter_10
-				trait = class_warrior_9
-				trait = class_warrior_10
-				trait = class_rogue_9
-				trait = class_rogue_10
-			}
-		}
+	OR = {
+		trait = class_hunter_9
+		trait = class_hunter_10
+		trait = class_warrior_9
+		trait = class_warrior_10
+		trait = class_rogue_9
+		trait = class_rogue_10
 	}
 }
 

--- a/events/wc_class_events.txt
+++ b/events/wc_class_events.txt
@@ -862,27 +862,21 @@ character_event = {
 			if = {
 				limit = { ROOT = { is_9_10_physical_class_trigger = yes } }
 				morale = 0.5
-				break = yes
 			}
-			if = {
+			else_if = {
 				limit = { ROOT = { is_7_8_physical_class_trigger = yes } }
 				morale = 0.4
-				break = yes
 			}
-			if = {
+			else_if = {
 				limit = { ROOT = { is_5_6_physical_class_trigger = yes } }
 				morale = 0.3
-				break = yes
 			}
-			if = {
+			else_if = {
 				limit = { ROOT = { is_3_4_physical_class_trigger = yes } }
 				morale = 0.2
-				break = yes
 			}
-			if = {
-				limit = { ROOT = { is_1_2_physical_class_trigger = yes } }
+			else = {
 				morale = 0.1
-				break = yes
 			}
 		}
 		liege = {
@@ -891,27 +885,21 @@ character_event = {
 				if = {
 					limit = { ROOT = { is_9_10_physical_class_trigger = yes } }
 					morale = 0.5
-					break = yes
 				}
-				if = {
+				else_if = {
 					limit = { ROOT = { is_7_8_physical_class_trigger = yes } }
 					morale = 0.4
-					break = yes
 				}
-				if = {
+				else_if = {
 					limit = { ROOT = { is_5_6_physical_class_trigger = yes } }
 					morale = 0.3
-					break = yes
 				}
-				if = {
+				else_if = {
 					limit = { ROOT = { is_3_4_physical_class_trigger = yes } }
 					morale = 0.2
-					break = yes
 				}
-				if = {
-					limit = { ROOT = { is_1_2_physical_class_trigger = yes } }
+				else = {
 					morale = 0.1
-					break = yes
 				}
 			}
 		}

--- a/events/wc_undead_events.txt
+++ b/events/wc_undead_events.txt
@@ -1109,7 +1109,7 @@ character_event = {
 					}
 					NOR = {
 						event_target:target_undead = { is_paladin_class_trigger = yes }
-						is_7_8_magic_class_trigger = yes
+						has_7_8_magic_class_or_higher_trigger = yes
 						trait = lich_king
 						AND = {
 							society_member_of = cult_of_the_damned
@@ -1148,7 +1148,7 @@ character_event = {
 			NOT = { event_target:target_undead = { is_paladin_class_trigger = yes } }
 			event_target:target_necromancer = {
 				OR = {
-					is_7_8_magic_class_trigger = yes
+					has_7_8_magic_class_or_higher_trigger = yes
 					trait = lich_king
 					AND = {
 						society_member_of = cult_of_the_damned
@@ -1192,7 +1192,7 @@ character_event = {
 			event_target:target_necromancer = {
 				OR = {
 					event_target:target_undead = { is_paladin_class_trigger = yes }
-					is_7_8_magic_class_trigger = yes
+					has_7_8_magic_class_or_higher_trigger = yes
 					trait = lich_king
 					AND = {
 						society_member_of = cult_of_the_damned
@@ -1232,7 +1232,7 @@ character_event = {
 			NOT = { event_target:target_undead = { is_paladin_class_trigger = yes } }
 			event_target:target_necromancer = {
 				OR = {
-					is_7_8_magic_class_trigger = yes
+					has_7_8_magic_class_or_higher_trigger = yes
 					trait = lich_king
 					AND = {
 						society_member_of = cult_of_the_damned

--- a/localisation/00_wc_generics.csv
+++ b/localisation/00_wc_generics.csv
@@ -353,7 +353,6 @@ hospital_building_3_desc;Hospital;;Hospital;;;;;;;;;;;x
 hospital_building_4_desc;Hospital Complex;;Krankenhaus;;;;;;;;;;;x
 hospital_building_5_desc;Divine Healing Complex;;Göttliches Krankenhaus;;;;;;;;;;;x
 leper_colony_1;Quarantine;;Quarantäne;;;;;;;;;;;x
-soup_kitchen_1;Orphanage;;Weisenhaus;;;;;;;;;;;x
 chapel_1;Hospice;;Hospiz;;;;;;;;;;;x
 translation_house_1;Embassy;;Botschaft;;;;;;;;;;;x
 pilgrims_inn_1;Bathhouse;;Badehaus;;;;;;;;;;;x
@@ -362,7 +361,6 @@ pharmacology_laboratory_1;Alchemist Lab;;Alchemistenlabor;;;;;;;;;;;x
 medical_academy_1;Priestly Clinic;;Priesterklinik;;;;;;;;;;;x
 wc_hsanctum;Divine Sanctum;;Göttliches Sanktuarium;;;;;;;;;;;x
 leper_colony_building_desc;Quarantine;;Quarantäne;;;;;;;;;;;x
-soup_kitchen_building_desc;Orphanage;;Weisenhaus;;;;;;;;;;;x
 chapel_building_desc;Hospice;;Hospiz;;;;;;;;;;;x
 translation_house_building_desc;Embassy;;Botschaft;;;;;;;;;;;x
 pilgrims_inn_building_desc;Bathhouse;;Badehaus;;;;;;;;;;;x

--- a/localisation/00_zuwc_united_localisation.csv
+++ b/localisation/00_zuwc_united_localisation.csv
@@ -1784,11 +1784,11 @@ EVTOPTB_WCFEL_1005;The ancient evil must remain in confinement!;;Das uralte Böse
 burn_evil_beings;Burn Evil Beings;;Verbrennt das Böse;;;;;;;;;;;x
 burn_evil_beings_desc;Burn all unholy characters as evil beings or get a reason to execute them if they're rulers. They deserve to die!;;Verbrennt alle unheiligen Wesen. Sie verdienen nur den Tod!;;;;;;;;;;;x
 burn_evil_being_effect_tooltip;§Y[This.GetBestName]§! is sentenced to be burnt\n;;§Y[This.GetBestName]§! wird zum Tod durch Verbrennung verurteilt.;;;;;;;;;;;x
-is_1_2_physical_class_trigger_tooltip;Physical class level is 1 or higher\n;;Phyische Klassenstufe beträgt 1 oder höher\n;;;;;;;;;;;x
-is_3_4_physical_class_trigger_tooltip;Physical class level is 3 or higher\n;;Phyische Klassenstufe beträgt 3 oder höher\n;;;;;;;;;;;x
-is_5_6_physical_class_trigger_tooltip;Physical class level is 5 or higher\n;;Phyische Klassenstufe beträgt 5 oder höher\n;;;;;;;;;;;x
-is_7_8_physical_class_trigger_tooltip;Physical class level is 7 or higher\n;;Phyische Klassenstufe beträgt 7 oder höher\n;;;;;;;;;;;x
-is_9_10_physical_class_trigger_tooltip;Physical class level is 9 or 10\n;;Phyische Klassenstufe beträgt 9 oder 10\n;;;;;;;;;;;x
+has_1_2_physical_class_or_higher_trigger_tooltip;Physical class level is 1 or higher\n;;Phyische Klassenstufe beträgt 1 oder höher\n;;;;;;;;;;;x
+has_3_4_physical_class_or_higher_trigger_tooltip;Physical class level is 3 or higher\n;;Phyische Klassenstufe beträgt 3 oder höher\n;;;;;;;;;;;x
+has_5_6_physical_class_or_higher_trigger_tooltip;Physical class level is 5 or higher\n;;Phyische Klassenstufe beträgt 5 oder höher\n;;;;;;;;;;;x
+has_7_8_physical_class_or_higher_trigger_tooltip;Physical class level is 7 or higher\n;;Phyische Klassenstufe beträgt 7 oder höher\n;;;;;;;;;;;x
+has_9_10_physical_class_trigger_tooltip;Physical class level is 9 or 10\n;;Phyische Klassenstufe beträgt 9 oder 10\n;;;;;;;;;;;x
 EVTDESC_WCCLS_105;You fought in the heat of battle alongside your soldiers. When the first unfortunate enemy soldier died by your hand, his blood splashed onto your tunic. You quickly rushed to the next opponent with a deafening cry!;;Ihr habt in der Hitze der Schlacht mit Euren Soldaten gekämpft. Als der erste unglückselige feindliche Soldat durch Eure Hand starb, spritzte sein Blut auf Euren Waffenrock. Ihr seid mit einem ohrenbetäubenden Schrei blitzschnell auf den nächsten Gegner zu gestürmt!;;;;;;;;;;;x
 EVTOPTA_WCCLS_105;Forward!;;Vorwärts!;;;;;;;;;;;x
 conjure_food;Conjure Food;Invoquer de la nourriture;Beschwört Essen;;;;;;;;;;;x

--- a/localisation_rus/000_ru_zuwc_united_localisation.csv
+++ b/localisation_rus/000_ru_zuwc_united_localisation.csv
@@ -1784,11 +1784,11 @@ EVTOPTB_WCFEL_1005;Древнее зло должно оставаться в заточении!;;;;;;;;;;;;;x
 burn_evil_beings;Сжечь исчадий зла;;;;;;;;;;;;;x
 burn_evil_beings_desc;Сжечь всех нечестивых персонажей как исчадий зла или получить претензию казнить их, если они правители. Они заслуживают смерти!;;;;;;;;;;;;;x
 burn_evil_being_effect_tooltip;§Y[This.GetBestName]§! приговорен[This.GetEndA] к сожжению;;;;;;;;;;;;;x
-is_1_2_physical_class_trigger_tooltip;Уровень физического класса 1 или выше\n;;;;;;;;;;;;;x
-is_3_4_physical_class_trigger_tooltip;Уровень физического класса 3 или выше\n;;;;;;;;;;;;;x
-is_5_6_physical_class_trigger_tooltip;Уровень физического класса 5 или выше\n;;;;;;;;;;;;;x
-is_7_8_physical_class_trigger_tooltip;Уровень физического класса 7 или выше\n;;;;;;;;;;;;;x
-is_9_10_physical_class_trigger_tooltip;Уровень физического класса 9 или выше\n;;;;;;;;;;;;;x
+has_1_2_physical_class_or_higher_trigger_tooltip;Уровень физического класса 1 или выше\n;;;;;;;;;;;;;x
+has_3_4_physical_class_or_higher_trigger_tooltip;Уровень физического класса 3 или выше\n;;;;;;;;;;;;;x
+has_5_6_physical_class_or_higher_trigger_tooltip;Уровень физического класса 5 или выше\n;;;;;;;;;;;;;x
+has_7_8_physical_class_or_higher_trigger_tooltip;Уровень физического класса 7 или выше\n;;;;;;;;;;;;;x
+has_9_10_physical_class_trigger_tooltip;Уровень физического класса 9 или выше\n;;;;;;;;;;;;;x
 EVTDESC_WCCLS_105;Вы сражаетесь в пылу сражения бок о бок со своими солдатами. После того как очередной враг пал и тёплая кровь брызнула вам на тунику, вы с оглушительным кличем бросились в атаку.;;;;;;;;;;;;;x
 EVTOPTA_WCCLS_105;Вперед!;;;;;;;;;;;;;x
 conjure_food;Сотворить Яства;;;;;;;;;;;;;x


### PR DESCRIPTION
# Changelog:
- Gender-equal barons and sometimes rulers (for example Shath'yar Naga) shouldn't appear with Agnatic Gender Law. They should appear with Absolute Cognatic.

# Secret Changelog (won't be included in patch notes, but needs testing):
- Fixed issue where 10 or 9 level necromancers or death knights couldn't turn characters into liches, vampires and death knights via Turn Undead decision.

# Big Brain Changelog (can be reviewed only via file checking):
- Added `has_<Level>_<Level+1>_physical_class_or_higher_trigger` triggers. This should fix issue where physical classes like warriors, rogues, hunters of 10 and 9 level were leveling up slower then magical classes like mage, shaman of level because both `is_7_8_physical_class_trigger` and `is_9_10_physical_class_trigger` returned true in `common_class_level_up_score`.