### PR TITLE
Reworked AI Status of Magic Logic

### DIFF
--- a/common/laws/wc_misc_laws.txt
+++ b/common/laws/wc_misc_laws.txt
@@ -73,7 +73,21 @@ laws = {
 				has_law = status_of_magic_0
 				has_law = status_of_magic_2
 			}
-			holder_scope = { dark_public_religion_trigger = no }
+			holder_scope = {
+				dark_public_religion_trigger = no
+			}
+			
+			# AI preferences
+			trigger_if = {
+				limit = { holder_scope = { ai = yes } }
+				trigger_if = {
+					limit = { has_law = status_of_magic_2 }
+					holder_scope = { ai_dislike_dark_magic_trigger = yes }
+				}
+				trigger_else = {
+					holder_scope = { ai_like_normal_magic_trigger = yes }
+				}
+			}
 		}
 		potential = {
 			holder_scope = { dark_public_religion_trigger = no }
@@ -83,16 +97,6 @@ laws = {
 		}
 		ai_will_do = {
 			factor = 0.1
-			modifier = {
-				factor = 0
-				has_law = status_of_magic_0
-				holder_scope = { ai_dislike_normal_magic_trigger = yes }
-			}
-			modifier = {
-				factor = 0
-				has_law = status_of_magic_2
-				holder_scope = { ai_like_dark_magic_trigger = yes }
-			}
 		}
 		ai_will_revoke = {
 			factor = 0
@@ -130,6 +134,18 @@ laws = {
 				has_law = status_of_magic_3
 			}
 			holder_scope = { dark_public_religion_trigger = no }
+			
+			# AI preferences
+			trigger_if = {
+				limit = { holder_scope = { ai = yes } }
+				trigger_if = {
+					limit = { has_law = status_of_magic_3 }
+					holder_scope = { ai_dislike_dark_magic_trigger = yes }
+				}
+				trigger_else = {
+					holder_scope = { ai_like_dark_magic_trigger = yes }
+				}
+			}
 		}
 		potential = {
 			# holder_scope = { dark_public_religion_trigger = no }
@@ -139,16 +155,6 @@ laws = {
 		}
 		ai_will_do = {
 			factor = 0.1
-			modifier = {
-				factor = 0
-				has_law = status_of_magic_1
-				holder_scope = { ai_dislike_dark_magic_trigger = yes }
-			}
-			modifier = {
-				factor = 0
-				has_law = status_of_magic_3
-				holder_scope = { ai_like_dark_magic_trigger = yes }
-			}
 		}
 		ai_will_revoke = {
 			factor = 0
@@ -171,6 +177,12 @@ laws = {
 				has_law = status_of_magic_2
 				holder_scope = { dark_public_religion_trigger = yes }
 			}
+			
+			# AI preferences
+			trigger_if = {
+				limit = { holder_scope = { ai = yes } }
+				holder_scope = { ai_like_dark_magic_trigger = yes }
+			}
 		}
 		potential = {
 			# holder_scope = { dark_public_religion_trigger = no }
@@ -180,10 +192,6 @@ laws = {
 		}
 		ai_will_do = {
 			factor = 0.1
-			modifier = {
-				factor = 0
-				holder_scope = { ai_dislike_dark_magic_trigger = yes }
-			}
 		}
 		ai_will_revoke = {
 			factor = 0

--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -2925,44 +2925,27 @@ true_religion_associated_with_sunwell_trigger = {
 # Needed for status_of_magic
 ai_like_dark_magic_trigger = {
 	OR = {
-		NOR = {
-			trait = zealous
-			true_religion = scarlet_light
-			true_religion = lightbound
-		}
 		is_dark_being_trigger = yes
 		is_warlock_class_trigger = yes
 		is_necromancer_class_trigger = yes
 		is_shadow_priest_class_trigger = yes
 		dark_true_religion_trigger = yes
+		trait = cynical
 	}
 }
 ai_dislike_dark_magic_trigger = {
-	is_dark_being_trigger = no
-	is_warlock_class_trigger = no
-	is_necromancer_class_trigger = no
-	is_shadow_priest_class_trigger = no
-	dark_true_religion_trigger = no
-	NOT = { trait = content }
+	ai_like_dark_magic_trigger = no
 	OR = {
 		trait = zealous
 		true_religion = scarlet_light
 		true_religion = lightbound
 	}
 }
-ai_dislike_normal_magic_trigger = {
-	is_dark_being_trigger = no
-	is_mage_class_trigger = no
-	is_warlock_class_trigger = no
-	is_necromancer_class_trigger = no
-	is_shadow_priest_class_trigger = no
-	dark_true_religion_trigger = no
-	secular_true_religion_trigger = no
-	NOT = { trait = content }
+ai_like_normal_magic_trigger = {
 	OR = {
-		trait = zealous
-		true_religion = scarlet_light
-		true_religion = lightbound
+		ai_like_dark_magic_trigger = yes
+		is_mage_class_trigger = yes
+		arcane_true_religion_trigger = yes
 	}
 }
 


### PR DESCRIPTION
### Terminology:
- Dark Religion: religion that believes Dark Magic is fine. Examples: Shath'yar, Shadowlander, Forgotten Shadow religions.
- Arcane Religion: religion where Arcane plays a big role. Examples: Sunwell, Titanic religions.
- Dark Being: character having Undead, Demon, Void Being traits.

### Changelog (public changelog):
- Reworked AI Status of Magic logic. AI no longer allows Dark or Arcane Magic if it's not interested in it because of class, religion or cynical trait.

### Secret Changelog (more detailed changelog):
- Reworked AI Status of Magic logic:
  - AI allows Dark Magic when it is either Dark Being, warlock, necromancer, shadow priest, truly follows Dark Religion or is cynical.
  - AI bans Dark Magic when it is either zealous or follows Scarlet Light or Lightbound religions and not interested in allowing it.
  - AI allows Arcane Magic when it is either Dark Being, warlock, necromancer, shadow priest, mage, truly follows Dark Religion or Arcane Religion or is cynical.

### How to Test
Use `observe` command to play different AI rulers like Tyrande (she shouldn't be interested in allowing Arcane magic). If AI ruler isn't interested in allowing magic, this part (on the screenshot below) should return false:

<details>
<summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/46384992/68710542-2e28d680-05b1-11ea-8d06-f3a49f1bba1b.png)

</details>

_**P.S. You should see these conditions (on the screenshot above) only if you observe AI. Players shouldn't see them.**_