### PR TITLE
Focus requirements

### DIFF
--- a/common/objectives/00_focuses.txt
+++ b/common/objectives/00_focuses.txt
@@ -186,15 +186,7 @@ focus_seduction = {
 	allow = {
 		# Warcraft
 		OR = {
-			is_dark_being_trigger = no
-			trait = creature_sayaadi
-		}
-		OR = {
 			can_marry_trigger = yes
-			trait = creature_sayaadi
-		}
-		OR = {
-			can_has_children_trigger = yes
 			trait = creature_sayaadi
 		}
 
@@ -341,15 +333,7 @@ focus_seduction = {
 			# Warcraft
 			is_untouchable_trigger = yes
 			NOR = {
-				is_dark_being_trigger = no
-				trait = creature_sayaadi
-			}
-			NOR = {
 				can_marry_trigger = yes
-				trait = creature_sayaadi
-			}
-			NOR = {
-				can_has_children_trigger = yes
 				trait = creature_sayaadi
 			}
 

--- a/common/objectives/00_focuses.txt
+++ b/common/objectives/00_focuses.txt
@@ -22,7 +22,6 @@ focus_rulership = {
 	
 	allow = {
 		# Warcraft
-		can_rule_peacefully_trigger = yes
 		evil_public_religion_trigger = no
 
 		is_adult = yes
@@ -75,7 +74,6 @@ focus_rulership = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
-			can_rule_peacefully_trigger = no
 			evil_public_religion_trigger = yes
 
 			prisoner = yes
@@ -105,7 +103,6 @@ focus_business = {
 	
 	allow = {
 		# Warcraft
-		can_rule_peacefully_trigger = yes
 		evil_public_religion_trigger = no
 
 		is_adult = yes
@@ -158,7 +155,6 @@ focus_business = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
-			can_rule_peacefully_trigger = no
 			evil_public_religion_trigger = yes
 
 			prisoner = yes
@@ -205,7 +201,6 @@ focus_seduction = {
 		is_adult = yes
 		NOT = { is_incapable = yes }
 		NOT = { trait = celibate }
-		NOT = { is_ascetic_trigger = yes }
 		NOT = { trait = eunuch }
 		custom_tooltip = {
 			text = is_not_ascetic
@@ -213,6 +208,9 @@ focus_seduction = {
 				NOT = { has_character_modifier = hindu_ascetic }
 				NOT = { has_character_modifier = buddhist_ascetic }
 				NOT = { has_character_modifier = jain_naked_ascetic }
+
+				# Warcraft
+				NOT = { is_ascetic_trigger = yes }
 			}
 		}
 	}
@@ -496,7 +494,6 @@ focus_hunting = {
 	
 	allow = {
 		# Warcraft
-		can_rule_peacefully_trigger = yes
 		evil_public_religion_trigger = no
 		NOT = { religion_group = druidism_group }
 		is_plant_race_trigger = no
@@ -561,7 +558,6 @@ focus_hunting = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
-			can_rule_peacefully_trigger = no
 			evil_public_religion_trigger = yes
 			religion_group = druidism_group
 
@@ -803,7 +799,6 @@ focus_family = {
 	
 	allow = {
 		# Warcraft
-		can_rule_peacefully_trigger = yes
 		can_marry_trigger = yes
 		evil_public_religion_trigger = no
 		
@@ -898,7 +893,6 @@ focus_family = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
-			can_rule_peacefully_trigger = no
 			can_marry_trigger = no
 			evil_public_religion_trigger = yes
 
@@ -931,7 +925,6 @@ focus_scholarship = {
 	
 	allow = {
 		# Warcraft
-		can_rule_peacefully_trigger = yes
 		evil_public_religion_trigger = no
 
 		is_adult = yes
@@ -1006,7 +999,6 @@ focus_scholarship = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
-			can_rule_peacefully_trigger = no
 			evil_public_religion_trigger = yes
 
 			is_incapable = yes

--- a/common/objectives/00_focuses.txt
+++ b/common/objectives/00_focuses.txt
@@ -185,6 +185,7 @@ focus_seduction = {
 	
 	allow = {
 		# Warcraft
+		evil_public_religion_trigger = no
 		OR = {
 			can_marry_trigger = yes
 			trait = creature_sayaadi
@@ -332,6 +333,7 @@ focus_seduction = {
 		OR = {
 			# Warcraft
 			is_untouchable_trigger = yes
+			evil_public_religion_trigger = yes
 			NOR = {
 				can_marry_trigger = yes
 				trait = creature_sayaadi

--- a/decisions/HF_sway_antagonize_decisions.txt
+++ b/decisions/HF_sway_antagonize_decisions.txt
@@ -24,12 +24,10 @@ targetted_decisions = {
 		allow = {
 			# Warcraft
 			is_untouchable_trigger = no
-			can_rule_peacefully_trigger = yes
 			evil_public_religion_trigger = no
 			has_invader_title_trigger = no
 			FROM = {
 				is_untouchable_trigger = no
-				can_rule_peacefully_trigger = yes
 				evil_public_religion_trigger = no
 				has_invader_title_trigger = no
 			}
@@ -148,12 +146,10 @@ targetted_decisions = {
 		allow = {
 			# Warcraft
 			is_untouchable_trigger = no
-			can_rule_peacefully_trigger = yes
 			evil_public_religion_trigger = no
 			has_invader_title_trigger = no
 			FROM = {
 				is_untouchable_trigger = no
-				can_rule_peacefully_trigger = yes
 				evil_public_religion_trigger = no
 				has_invader_title_trigger = no
 			}

--- a/decisions/way_of_life_decisions.txt
+++ b/decisions/way_of_life_decisions.txt
@@ -91,7 +91,6 @@ targetted_decisions = {
 		potential = {
 			# Warcraft
 			is_untouchable_trigger = no
-			is_dark_being_trigger = no
 			FROM = { can_has_sexual_relation_with_prev = yes }
 			
 			is_marriage_adult = yes

--- a/decisions/way_of_life_decisions.txt
+++ b/decisions/way_of_life_decisions.txt
@@ -91,6 +91,7 @@ targetted_decisions = {
 		potential = {
 			# Warcraft
 			is_untouchable_trigger = no
+			evil_public_religion_trigger = no
 			FROM = { can_has_sexual_relation_with_prev = yes }
 			
 			is_marriage_adult = yes


### PR DESCRIPTION
#### Public changelog:
- Allowed undead and other dark beings that can have _relationships_ to pick **Seduction** focus.
- Disallowed evil religions to pick **Seduction** focus.
**_Note:_** Zuzu's request

#### Dev changelog:
- Removed `can_rule_peacefully_trigger` from focuses, sway and antagonize, because `evil_public_religion_trigger` already implies `can_rule_peacefully_trigger`.
- Changed **Seduction** focus requirement tooltip about being ascetic.