### PR TITLE
Bugfixes

### DIFF
--- a/common/achievements.txt
+++ b/common/achievements.txt
@@ -1,0 +1,1 @@
+# Warcraft

--- a/common/retinue_subunits/00_retinue_subunits.txt
+++ b/common/retinue_subunits/00_retinue_subunits.txt
@@ -2072,7 +2072,7 @@ wc_ret_cul_giant = {
 		# is_tribal = no
 		OR = {
 			culture = frozen_giant
-			cuture = storm_giant
+			culture = storm_giant
 		}
 	}
 

--- a/common/scripted_effects/wc_history_scripted_effects.txt
+++ b/common/scripted_effects/wc_history_scripted_effects.txt
@@ -1,5 +1,7 @@
 purge_historical_character_effect = {
 	dynasty = none
+	leave_council_position_no_opinion_effect = yes
+	leave_society_if_part_of_society_effect = yes
 	death = { death_reason = death_missing }
 }
 add_patron_trait_character_effect = {

--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -1994,7 +1994,7 @@ add_default_traits = {
 				chance = 20
 				stereotypical_traits_game_rule_score = yes
 				
-				if = { limit = { NOT = { trait = stubborn } add_trait = stubborn } }
+				if = { limit = { NOT = { trait = stubborn } } add_trait = stubborn }
 			}
 		}
 		

--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -1907,7 +1907,7 @@ add_default_traits = {
 				chance = 20
 				stereotypical_traits_game_rule_score = yes
 				
-				if = { limit = { NOT = { trait = erudite } add_trait = erudite } }
+				if = { limit = { NOT = { trait = erudite } } add_trait = erudite }
 			}
 		}
 		

--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -2942,7 +2942,7 @@ ruler_sell_land_to_holy_order_effect = {
 				show_scope_change = no
 
 				if = {
-					limit = { limit = { holder_scope = { character = event_target:target_ruler } } }
+					limit = { holder_scope = { character = event_target:target_ruler } }
 					ruler_grant_land_to_holy_order_effect = yes
 				}
 			}

--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -2310,8 +2310,8 @@ cleanup_province_as_target_settler_effect = {
 					has_province_modifier = undead_province
 					event_target:target_settler = {
 						NOT = {
-							trait = undead
-							
+							trait = being_undead
+
 							religion_group = necromancy_group
 						}
 					}

--- a/common/scripted_effects/wc_society_scripted_effects.txt
+++ b/common/scripted_effects/wc_society_scripted_effects.txt
@@ -372,25 +372,31 @@ join_society_twilights_hammer_cult_effect = {
 	join_society = twilights_hammer_cult
 }
 join_society_cenarion_circle_effect = {
-	join_society = cenarion_circle
 	if = {
-		limit = {
-			ai = yes
-			
-			is_druid_class_trigger = no
+		limit = { NOT = { is_in_society = cenarion_circle } }
+		join_society = cenarion_circle
+		if = {
+			limit = {
+				ai = yes
+				
+				is_druid_class_trigger = no
+			}
+			ai_add_druid_class_effect = yes
 		}
-		ai_add_druid_class_effect = yes
 	}
 }
 join_society_sisterhood_of_elune_effect = {
-	join_society = sisterhood_of_elune
 	if = {
-		limit = {
-			ai = yes
-			
-			is_priest_class_trigger = no
+		limit = { NOT = { is_in_society = sisterhood_of_elune } }
+		join_society = sisterhood_of_elune
+		if = {
+			limit = {
+				ai = yes
+				
+				is_priest_class_trigger = no
+			}
+			ai_add_priest_class_effect = yes
 		}
-		ai_add_priest_class_effect = yes
 	}
 }
 # Join society based on being_recruited_by_ flag

--- a/common/scripted_effects/wc_society_scripted_effects.txt
+++ b/common/scripted_effects/wc_society_scripted_effects.txt
@@ -503,6 +503,13 @@ set_twilights_hammer_cult_recruitment_flags_effect = {
 	set_character_flag = being_recruited_by_twilights_hammer_cult
 }
 
+leave_society_if_part_of_society_effect = {
+	if = {
+		limit = { NOT = { is_in_society = yes } }
+		leave_society = yes
+	}
+}
+
 betray_and_leave_society_effect = {
 	hidden_effect = {
 		if = {

--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -377,7 +377,10 @@ title_can_be_lost_trigger = {
 	mercenary = no
 	holy_order = no
 	clan = no
-	NOT = { holding_type = family_palace }
+	trigger_if = {
+		limit = { tier = BARON }
+		NOT = { holding_type = family_palace }
+	}
 	invader_title_trigger = no
 	dragonflight_title_trigger = no
 }

--- a/events/wc_fel_events.txt
+++ b/events/wc_fel_events.txt
@@ -881,7 +881,7 @@ character_event = {
 				}
 
 				# Removes wrong traits
-				remove_trait = chariable
+				remove_trait = charitable
 				remove_trait = humble
 				remove_trait = honest
 				remove_trait = content

--- a/events/wc_loa_events.txt
+++ b/events/wc_loa_events.txt
@@ -615,7 +615,7 @@ character_event = {
 				follower_of_rezan       = { ROOT = { add_character_modifier = { name = follower_of_rezan 		duration = -1	}	}	}
 				follower_of_sethraliss  = { ROOT = { add_character_modifier = { name = follower_of_sethraliss	duration = -1	}	}	}
 				follower_of_torcali     = { ROOT = { add_character_modifier = { name = follower_of_torcali		duration = -1	}	}	}
-				follower_of_torga       = { ROOT = { add_character_modifier = { name = follower_of_torg 		duration = -1	}	}	}
+				follower_of_torga       = { ROOT = { add_character_modifier = { name = follower_of_torga 		duration = -1	}	}	}
 				follower_of_zanza       = { ROOT = { add_character_modifier = { name = follower_of_zanza 		duration = -1	}	}	}
 			}
 			opinion = {

--- a/events/wc_third_war_events.txt
+++ b/events/wc_third_war_events.txt
@@ -1125,8 +1125,8 @@ character_event = {
 			is_capital = yes
 
 			location = {
+				has_wonder = wonder_sunwell
 				wonder = {
-					has_wonder = wonder_sunwell
 					NOR = {
 						has_wonder_flag = wonder_lightwell_flag
 						has_wonder_flag = wonder_deathwell_flag

--- a/history/characters/10000_orc.txt
+++ b/history/characters/10000_orc.txt
@@ -59,7 +59,7 @@
 				leave_council_position_no_opinion_effect = yes
 				give_minor_title = title_shadow_council_member_2
 			}
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 		}
 	}
@@ -282,7 +282,7 @@
 	# }
 	# 583.1.1={
 		# effect={
-			# leave_society = yes
+			# leave_society_if_part_of_society_effect = yes
 			# join_society_shadow_council_effect = yes
 			# society_rank_up = 1
 		# }
@@ -390,7 +390,7 @@
 				give_job_title = job_spymaster
 			}
 			
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			set_society_grandmaster = yes
 			add_society_currency_massive_effect = yes
@@ -418,7 +418,7 @@
 		employer = 10000
 		effect={
 			opinion = { modifier = opinion_loyal_servant who = 10015 }
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
 		}
@@ -450,7 +450,7 @@
 		employer = 10000
 		effect={
 			opinion = { modifier = opinion_loyal_servant who = 10015 }
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
 		}
@@ -489,7 +489,7 @@
 		employer = 10000
 		effect={
 			opinion = { modifier = opinion_loyal_servant who = 10015 }
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
 		}
@@ -590,7 +590,7 @@
 		employer = 10000
 		effect={
 			opinion = { modifier = opinion_loyal_servant who = 10015 }
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
 		}

--- a/history/characters/52000_ogre.txt
+++ b/history/characters/52000_ogre.txt
@@ -17,7 +17,7 @@
 	575.6.18={
 		add_trait = class_warlock_7
 		effect={
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_shadow_council_effect = yes
 			society_rank_up = 2
 		}
@@ -30,7 +30,7 @@
 		remove_trait = class_warlock_7
 		add_trait = class_shadow_priest_7
 		effect = {
-			leave_society = yes
+			leave_society_if_part_of_society_effect = yes
 			join_society_twilights_hammer_cult_effect = yes
 			set_society_grandmaster = yes
 			add_society_currency_massive_effect = yes


### PR DESCRIPTION
#### Changelog:
- Fixed giant retinue not being availible for storm giants.
- Fixed Torga loa modifier gaining in "choose Loa of your liege" event option.
- Fixed that third Legion invasion leader could be charitable.
- Fixed that erudite trait were not assigned to stereotypically erudite characters.
- Fixed that stubborn trait were not assigned to stereotypically stubborn characters.

#### Dev Changelog:
- Replaced non-existing undead trait with `being_undead` in triggers
- Deleted unnecessary `limit` block inside `limit` block
- Fixed achievements-related errors in `error.log` by deleting achievements
- Fixed `[effectimplementation.cpp:22757]: Script Assert! assert: "!"Already part of a society"", type: "join_society"`
- Fixed `[effectimplementation.cpp:22816]: Script Assert! assert: "!"Character is not part of a Society in leave_society effect""`
- Fixed `[triggerimplementation.cpp:27105]: Script Assert! assert: "false && "CHasWonderTrigger has invalid Scope"", type: "none", location: " file: events/wc_third_war_events.txt line: 1129"`
- Fixed `[triggerimplementation.cpp:14866]: Script Assert! message: CHoldingTypeTrigger has wrong Scope!, assert: "( pTitle->IsValid() && pTitle->GetTier() <= COUNT ) || Scope.GetProvince() != 0", type: "none", location: " file: common/scripted_triggers/wc_scripted_triggers.txt line: 380"`