### PR TITLE
#1071 Exploit

### DIFF
--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -829,6 +829,11 @@ prev_burn_evil_being_this_effect = {
 								factor = 0
 								PREV = { ai = yes }		# AI always kill
 							}
+							# Anti-exploit
+							modifier = {
+								factor = 25
+								is_heir = yes
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Player's heirs are less likely to be burnt via **Burn Evil Being** and **Burn Evil Beings** decisions.

My solution to #1071 exploit. Gib your opinion.