### PR TITLE
Interface fix

### DIFF
--- a/interface/domestic_treasury.gui
+++ b/interface/domestic_treasury.gui
@@ -260,7 +260,10 @@ guiTypes = {
 		}
 		iconType = {
 			name = "icon"
-			position = { x=57 y=1 }
+
+			# Warcraft
+			position = { x=58 y=1 }
+
 			quadTextureSprite = "GFX_test_64"
 		}
 		iconType = {


### PR DESCRIPTION
#### Changelog:
- Attempted to fix vanilla bug where artifact icons were shifted a bit to the right, so you could see 1 pixel line of inventory background between artifact icon and artifact frame

<details>
<summary>Before / After</summary>

![ck2_1](https://user-images.githubusercontent.com/46576860/73610843-c781ea80-45ec-11ea-861d-c7c739f16c48.png)

</details>