### PR TITLE
Fixed #942 Crash

### DIFF
--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -2517,10 +2517,19 @@ target_settler_declare_war_effect = {
 						reverse_unsafe_war = {
 							target = event_target:target_settler
 							casus_belli = claim_all
-							thirdparty_title = THIS
 						}
 					}
-					else = {
+					else_if = {
+						limit = {
+							event_target:target_settler = {
+								can_use_cb = {
+									target = PREV
+									casus_belli = claim
+									thirdparty_title = PREVPREVPREV
+									only_check_triggers = yes
+								}
+							}
+						}
 						reverse_unsafe_war = {
 							target = event_target:target_settler
 							casus_belli = claim

--- a/events/wc_third_war_events.txt
+++ b/events/wc_third_war_events.txt
@@ -626,7 +626,54 @@ narrative_event = {
 			create_e_horde_effect = yes
 		}
 		
-		# Grant titles to trolls
+		# Grants titles to trolls and invited clan
+		73 = { province_event = { id = WCTHW.125 days = 1 } } # Needs 1 day to prevent crash
+	}
+
+	option = {
+		trigger = {
+			OR = {
+				character = ROOT
+				primary_title = {
+					OR = {
+						has_title_flag = clan_sailed_to_kalimdor_flag
+						has_title_flag = trolls_sailed_to_kalimdor_flag
+					}
+				}
+			}
+		}
+		name = EVTOPTA_WCTHW_120
+		
+		# if = {
+			# limit = { trait = travelling }
+			# remove_trait = travelling
+		# }
+	}
+
+	option = {
+		trigger = {
+			NOR = {
+				character = ROOT
+				primary_title = {
+					OR = {
+						has_title_flag = clan_sailed_to_kalimdor_flag
+						has_title_flag = trolls_sailed_to_kalimdor_flag
+					}
+				}
+			}
+		}
+		name = INTERESTING
+	}
+}
+# Grants titles to trolls and invited clan
+province_event = {
+	id = WCTHW.125
+	
+	is_triggered_only = yes
+	hide_window = yes
+	
+	immediate = {
+		# Grants titles to trolls
 		event_target:target_trolls = {
 			if = {
 				limit = { has_title_flag = trolls_sailed_to_kalimdor_flag }
@@ -718,7 +765,7 @@ narrative_event = {
 			}
 		}
 		
-		# Grant title to invited clan
+		# Grants title to invited clan
 		event_target:target_clan = {
 			if = {
 				limit = { has_title_flag = clan_sailed_to_kalimdor_flag }
@@ -753,41 +800,6 @@ narrative_event = {
 				}
 			}
 		}
-	}
-
-	option = {
-		trigger = {
-			OR = {
-				character = ROOT
-				primary_title = {
-					OR = {
-						has_title_flag = clan_sailed_to_kalimdor_flag
-						has_title_flag = trolls_sailed_to_kalimdor_flag
-					}
-				}
-			}
-		}
-		name = EVTOPTA_WCTHW_120
-		
-		# if = {
-			# limit = { trait = travelling }
-			# remove_trait = travelling
-		# }
-	}
-
-	option = {
-		trigger = {
-			NOR = {
-				character = ROOT
-				primary_title = {
-					OR = {
-						has_title_flag = clan_sailed_to_kalimdor_flag
-						has_title_flag = trolls_sailed_to_kalimdor_flag
-					}
-				}
-			}
-		}
-		name = INTERESTING
 	}
 }
 
@@ -1065,7 +1077,28 @@ narrative_event = {
 		# Spawns army for start
 		spawn_colonial_troops_effect = yes
 		
-		# Grant titles to refugees
+		# Grants titles to refugees
+		73 = { province_event = { id = WCTHW.160 days = 1 } } # Needs 1 day to prevent crash
+	}
+
+	option = {
+		trigger = { character = ROOT }
+		name = EVTOPTA_WCTHW_155
+	}
+
+	option = {
+		trigger = { NOT = { character = ROOT } }
+		name = INTERESTING
+	}
+}
+# Grants titles to refugees
+province_event = {
+	id = WCTHW.160
+	
+	is_triggered_only = yes
+	hide_window = yes
+	
+	immediate = {
 		event_target:target_refugees = {
 			if = {
 				limit = { has_title_flag = refugees_sailed_to_kalimdor_flag }
@@ -1095,16 +1128,6 @@ narrative_event = {
 				}
 			}
 		}
-	}
-
-	option = {
-		trigger = { character = ROOT }
-		name = EVTOPTA_WCTHW_155
-	}
-
-	option = {
-		trigger = { NOT = { character = ROOT } }
-		name = INTERESTING
 	}
 }
 


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed #942 crash after the Theramore founding.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Download the attached save and try to play a month.
[CrashSave.zip](https://github.com/Warcraft-GoA-Development-Team/Warcraft-Guardians-of-Azeroth/files/4174865/CrashSave.zip)
Also, try to play on the master branch with this save, you should get a crash.


## Note:
The crash was caused by the liege of Fray usurping Fray after he/she lost all his/her titles. As a result, the Alliance refuges and the liege were usurping Fray at the same moment.
