### PR TITLE
Fixed #1154 Issue

### DIFF
--- a/common/cb_types/00_cb_types.txt
+++ b/common/cb_types/00_cb_types.txt
@@ -6401,16 +6401,6 @@ bid_for_independence = {
 		# Warcraft
 		attacker = {
 			free_from_lich_king_effect = yes
-			hidden_effect = {
-				any_realm_character = {
-					limit = {
-						NOT = { character = PREV }
-						
-						can_break_scourge_mind_control_trigger = yes
-					}
-					free_from_lich_king_effect = yes
-				}
-			}
 		}
 		
 		hidden_tooltip = { fire_haruspicy_event_effect = yes }
@@ -8730,16 +8720,6 @@ cb_faction_independence = {
 		# Warcraft
 		attacker = {
 			free_from_lich_king_effect = yes
-			hidden_effect = {
-				any_realm_character = {
-					limit = {
-						NOT = { character = PREV }
-						
-						can_break_scourge_mind_control_trigger = yes
-					}
-					free_from_lich_king_effect = yes
-				}
-			}
 		}
 		
 		hidden_tooltip = { fire_haruspicy_event_effect = yes }

--- a/common/scripted_effects/wc_scripted_effects.txt
+++ b/common/scripted_effects/wc_scripted_effects.txt
@@ -3467,6 +3467,11 @@ remove_mind_control_modifier_effect = {
 }
 # Increases stage of Mind Control and makes undead loyal
 increase_mind_control_stage_effect = {
+	hidden_effect = {
+		# Changes religion of your provinces
+		change_undead_demesne_provinces_religion_to_root_effect = yes
+	}
+	
 	if = {
 		limit = {
 			NOR = {
@@ -3569,9 +3574,11 @@ decrease_mind_control_stage_effect = {
 		}
 		add_character_modifier = { name = mind_control_4 duration = -1 }
 		hidden_effect = {
-			any_realm_character = {
+			any_realm_lord = {
 				limit = {
 					NOT = { character = ROOT }
+					
+					NOT = { tier = BARON } #Barons stay loyal
 					
 					can_break_scourge_mind_control_trigger = yes
 				}
@@ -3593,9 +3600,11 @@ decrease_mind_control_stage_effect = {
 		}
 		add_character_modifier = { name = mind_control_3 duration = -1 }
 		hidden_effect = {
-			any_realm_character = {
+			any_realm_lord = {
 				limit = {
 					NOT = { character = ROOT }
+					
+					NOT = { tier = BARON } #Barons stay loyal
 					
 					can_break_scourge_mind_control_trigger = yes
 				}
@@ -3613,9 +3622,11 @@ decrease_mind_control_stage_effect = {
 	else = {
 		add_character_modifier = { name = mind_control_2 duration = -1 }
 		hidden_effect = {
-			any_realm_character = {
+			any_realm_lord = {
 				limit = {
 					NOT = { character = ROOT }
+					
+					NOT = { tier = BARON } #Barons stay loyal
 					
 					can_break_scourge_mind_control_trigger = yes
 				}
@@ -3958,5 +3969,17 @@ free_scourge_from_legion_effect = {
 	custom_tooltip = {
 		text = you_are_no_longer_pawn_of_the_legion_tooltip
 		clr_global_flag = scourge_is_under_legion_control_flag
+	}
+}
+
+# Changes religion of your undead provinces
+change_undead_demesne_provinces_religion_to_root_effect = {
+	any_demesne_province = {
+		limit = {
+			NOT = { religion = ROOT }
+			
+			has_province_modifier = undead_province
+		}
+		religion = ROOT
 	}
 }

--- a/events/wc_plague_events.txt
+++ b/events/wc_plague_events.txt
@@ -347,10 +347,8 @@ character_event = {
 		# Necromancer
 		if = {
 			limit = {
-				event_target:target_necromancer = {
-					NOT = { character = ROOT }
-					NOT = { e_scourge = { holder_scope = { character = PREVPREV } } }
-				}
+				event_target:target_necromancer = { NOT = { character = ROOT } }
+				NOT = { e_scourge = { holder_scope = { character = event_target:target_necromancer } } }
 			}
 			if = {
 				limit = { NOT = { has_opinion_modifier = { who = event_target:target_necromancer modifier = opinion_loyal_servant } } }
@@ -365,18 +363,16 @@ character_event = {
 				set_secret_religion = event_target:target_necromancer
 			}
 		}
-		# Lich King if you're necromancer worships e_scourge religion
+		# Lich King if your necromancer worships e_scourge religion
 		if = {
 			limit = {
 				can_be_mind_controlled_by_scourge_trigger = yes
 				e_scourge = {
 					has_holder = yes
 					holder_scope = {
-						event_target:target_necromancer = {
-							OR = {
-								character = PREV
-								true_religion = { target = PREV target_type = public }
-							}
+						OR = {
+							character = event_target:target_necromancer
+							religion = { target = event_target:target_necromancer target_type = true }
 						}
 					}
 				}

--- a/events/wc_undead_events.txt
+++ b/events/wc_undead_events.txt
@@ -2256,16 +2256,6 @@ character_event = {
 	option = {
 		name = EXCELLENT
 
-		# Converts your provinces
-		hidden_effect = {
-			any_demesne_province = {
-				limit = {
-					NOT = { religion = ROOT }
-					has_province_modifier = undead_province
-				}
-				religion = ROOT
-			}
-		}
 		# Increases stage of Mind Control and makes undead loyal
 		increase_mind_control_stage_effect = yes
 	}
@@ -2332,17 +2322,9 @@ character_event = {
 	picture = GFX_evt_scourge_army
 
 	is_triggered_only = yes
-
+	
 	trigger = {
-		trait = being_undead
-		NOT = { has_character_flag = freed_from_lich_king_flag }
-		NOT = { has_landed_title = e_scourge }
-		e_scourge = {
-			has_holder = yes
-			holder_scope = {
-				NOT = { religion = PREVPREV }
-			}
-		}
+		can_be_mind_controlled_by_scourge_trigger = yes
 	}
 
 	immediate = {
@@ -2358,6 +2340,8 @@ character_event = {
 				show_scope_change = no
 				ROOT = {
 					show_scope_change = no
+					
+					# Changes religion
 					if = {
 						limit = { NOT = { religion = PREV } }
 						religion = PREV
@@ -2369,26 +2353,15 @@ character_event = {
 					hidden_effect = {
 						if = {
 							limit = {
-								is_ruler = yes
-								higher_tier_than = COUNT
+								is_landed = yes
+								higher_tier_than = BARON
 							}
-							any_demesne_province = {
-								limit = {
-									NOT = { religion = PREVPREV }
-									has_province_modifier = undead_province
-								}
-								religion = PREVPREV
-							}
+							# Changes religion of your provinces
+							change_undead_demesne_provinces_religion_to_root_effect = yes
 						}
 					}
-					if = {
-						limit = { has_opinion_modifier = { who = PREV  modifier = opinion_evil_tyrant } }
-						remove_opinion = { modifier = opinion_evil_tyrant who = PREV }
-					}
-					if = {
-						limit = { NOT = { has_opinion_modifier = { who = PREV  modifier = opinion_loyal_servant } } }
-						opinion = { modifier = opinion_loyal_servant who = PREV }
-					}
+					remove_opinion = { modifier = opinion_evil_tyrant who = PREV }
+					opinion = { modifier = opinion_loyal_servant who = PREV }
 				}
 			}
 		}
@@ -2401,6 +2374,10 @@ character_event = {
 	picture = GFX_evt_scourge_army
 
 	is_triggered_only = yes
+	
+	trigger = {
+		can_break_scourge_mind_control_trigger = yes
+	}
 	
 	immediate = {
 		log = "WCUND.1109 fired for [Root.GetBestName]"
@@ -2492,40 +2469,52 @@ character_event = {
 						culture = event_target:target_culture
 					}
 					hidden_effect = {
-						# Changes religion and culture of your provinces
-						any_demesne_province = {
+						if = {
 							limit = {
-								OR = {
-									religion = PREVPREV #Has Lich King's religion
-									culture = scourge
-								}
+								is_landed = yes
+								higher_tier_than = BARON
 							}
-							if = {
-								limit = { religion = PREVPREV } #Has Lich King's religion
-								religion = ROOT
-							}
-							if = {
-								limit = { culture = scourge }
-								culture = ROOT
-							}
-						}
-						# Changes religion and culture of your courtiers
-						any_courtier_or_vassal = {
-							limit = {
-								OR = {
+							# Changes religion and culture of your provinces
+							any_demesne_province = {
+								limit = {
 									OR = {
 										religion = PREVPREV #Has Lich King's religion
 										culture = scourge
 									}
 								}
+								if = {
+									limit = { religion = PREVPREV } #Has Lich King's religion
+									religion = ROOT
+								}
+								if = {
+									limit = { culture = scourge }
+									culture = ROOT
+								}
 							}
-							if = {
-								limit = { religion = PREVPREV } #Has Lich King's religion
-								religion = ROOT
+						}
+						if = {
+							limit = {
+								is_ruler = yes
 							}
-							if = {
-								limit = { culture = scourge }
-								culture = ROOT
+							# Changes religion and culture of your courtiers
+							any_courtier_or_vassal = {
+								limit = {
+									ai = yes
+									
+									OR = {
+										religion = PREVPREV #Has Lich King's religion
+										culture = scourge
+									}
+									can_break_scourge_mind_control_trigger = yes
+								}
+								if = {
+									limit = { religion = PREVPREV } #Has Lich King's religion
+									religion = ROOT
+								}
+								if = {
+									limit = { culture = scourge }
+									culture = ROOT
+								}
 							}
 						}
 					}


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed #1154 issue where your religion or/and culture could change to **Forsaken** culture and **Forgotten Shadow** religion without any event if you was Scourge's vassal.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Scripting changelog (ignore if you can't read CK2 scripting):
- An event where undead breaks free from the Lich King shall be less CPU-heavy because I replaced `any_realm_character` by `any_realm_lord`.
- Purged using of `free_from_lich_king_effect` to `any_realm_character`. It's not needed since `free_from_lich_king_effect` converts your direct vassals and courtiers.
- Created `change_undead_demesne_provinces_religion_to_root_effect` scripted effect.
- Changed scopes in `wc_plague_events.txt` since PREV's not really clear.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
1) Start in 603.
2) Wait till the Scourge gets Lordaeron and more vassals.
3) Switch to the Lich King and use `event WCUND.1112` console command to decrease Lich King's mind control and make some undead vassals free and Forsaken.