### PR TITLE
Can Interact Triggers

### DIFF
--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -4512,8 +4512,30 @@ lich_king_vision_trigger = {
 can_positive_interact_with_prev_hiddenly_trigger = {
 	OR = {
 		can_positive_interact_with_prev_publicly_trigger = yes
-		# PREV can interact with those who shares PREV's religion truly
+		# PREV can interact with those who follows orcish_fel and burning_legion_religion truly
+		# If PREV is orcish_fel, PREV can interact with those who doesn't follow evil religions truly
 		trigger_if = {
+			limit = {
+				PREV = {
+					OR = {
+						true_religion = orcish_fel
+						true_religion = burning_legion_religion
+					}
+				}
+			}
+			OR = {
+				true_religion = orcish_fel
+				true_religion = burning_legion_religion
+				trigger_if = {
+					limit = {
+						PREV = { true_religion = orcish_fel }
+					}
+					evil_true_religion_trigger = no
+				}
+			}
+		}
+		# PREV can interact with those who shares PREV's religion truly
+		trigger_else_if = {
 			limit = {
 				PREV = { evil_true_religion_trigger = yes }
 			}
@@ -4526,8 +4548,30 @@ can_positive_interact_with_prev_hiddenly_trigger = {
 	}
 }
 can_positive_interact_with_prev_publicly_trigger = {
-	# PREV can interact with those who shares PREV's religion publicly
+	# PREV can interact with those who follows orcish_fel and burning_legion_religion publicly
+	# If PREV is orcish_fel, PREV can interact with those who doesn't follow evil religions publicly
 	trigger_if = {
+		limit = {
+			PREV = {
+				OR = {
+					religion = orcish_fel
+					religion = burning_legion_religion
+				}
+			}
+		}
+		OR = {
+			religion = orcish_fel
+			religion = burning_legion_religion
+			trigger_if = {
+				limit = {
+					PREV = { religion = orcish_fel }
+				}
+				evil_public_religion_trigger = no
+			}
+		}
+	}
+	# PREV can interact with those who shares PREV's religion publicly
+	trigger_else_if = {
 		limit = {
 			PREV = { evil_public_religion_trigger = yes }
 		}

--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -4510,30 +4510,19 @@ lich_king_vision_trigger = {
 }
 
 can_positive_interact_with_prev_hiddenly_trigger = {
-	# PREV can interact with those who shares PREV's religion publicly or secretly
-	trigger_if = {
-		limit = {
-			PREV = { evil_public_religion_trigger = yes }
+	OR = {
+		can_positive_interact_with_prev_publicly_trigger = yes
+		# PREV can interact with those who shares PREV's religion truly
+		trigger_if = {
+			limit = {
+				PREV = { evil_true_religion_trigger = yes }
+			}
+			true_religion = PREV
 		}
-		OR = {
-			religion = PREV
-			secret_religion = { target = PREV target_type = public }
+		# Otherwise, PREV can interact with those who doesn't follow evil religions truly
+		trigger_else = {
+			evil_true_religion_trigger = no
 		}
-	}
-	# PREV can interact with those who shares PREV's religion publicly or secretly or who doesn't follow evil religions
-	trigger_else_if = {
-		limit = {
-			PREV = { evil_secret_religion_trigger = yes }
-		}
-		OR = {
-			evil_public_religion_trigger = no
-			secret_religion = PREV
-			religion = { target = PREV target_type = secret }
-		}
-	}
-	# Otherwise, PREV can interact with those who doesn't follow evil religions
-	trigger_else = {
-		evil_public_religion_trigger = no
 	}
 }
 can_positive_interact_with_prev_publicly_trigger = {
@@ -4544,7 +4533,7 @@ can_positive_interact_with_prev_publicly_trigger = {
 		}
 		religion = PREV
 	}
-	# Otherwise, PREV can interact with those who doesn't follow evil religions
+	# Otherwise, PREV can interact with those who doesn't follow evil religions publicly
 	trigger_else = {
 		evil_public_religion_trigger = no
 	}

--- a/common/scripted_triggers/wc_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_scripted_triggers.txt
@@ -817,6 +817,14 @@ evil_public_religion_trigger = {
 		religion = old_gods_worship
 	}
 }
+evil_secret_religion_trigger = {
+	OR = {
+		secret_religion = death_god
+		# secret_religion = orcish_fel
+		secret_religion = burning_legion_religion
+		secret_religion = old_gods_worship
+	}
+}
 dark_public_religion_trigger = {
 	OR = {
 		religion_group = fel_group
@@ -2820,13 +2828,7 @@ is_plant_race_trigger = {
 
 # Can be appointed marshal, regent, steward etc (basically, all importrant titles)
 can_be_appointed_trigger = {
-	trigger_if = {
-		limit = { liege = { evil_public_religion_trigger = yes } }
-		religion = liege
-	}
-	trigger_else = {
-		evil_public_religion_trigger = no
-	}
+	liege = { can_positive_interact_with_prev_publicly_trigger = yes }
 }
 
 # Analogs of the Hermetics in the Warcraft universe
@@ -4175,22 +4177,10 @@ fury_of_wolf_human_event_trigger = {
 }
 
 can_improve_relations_with_root_trigger = {
-	trigger_if = {
-		limit = { ROOT = { evil_public_religion_trigger = yes } }
-		religion = ROOT
-	}
-	trigger_else = {
-		evil_public_religion_trigger = no
-	}
+	ROOT = { can_positive_interact_with_prev_publicly_trigger = yes }
 }
 can_improve_relations_with_from_trigger = {
-	trigger_if = {
-		limit = { FROM = { evil_public_religion_trigger = yes } }
-		religion = FROM
-	}
-	trigger_else = {
-		evil_public_religion_trigger = no
-	}
+	FROM = { can_positive_interact_with_prev_publicly_trigger = yes }
 }
 
 ashbringer_owner_event_trigger = {
@@ -4516,5 +4506,46 @@ lich_king_vision_trigger = {
 				}
 			}
 		}
+	}
+}
+
+can_positive_interact_with_prev_hiddenly_trigger = {
+	# PREV can interact with those who shares PREV's religion publicly or secretly
+	trigger_if = {
+		limit = {
+			PREV = { evil_public_religion_trigger = yes }
+		}
+		OR = {
+			religion = PREV
+			secret_religion = { target = PREV target_type = public }
+		}
+	}
+	# PREV can interact with those who shares PREV's religion publicly or secretly or who doesn't follow evil religions
+	trigger_else_if = {
+		limit = {
+			PREV = { evil_secret_religion_trigger = yes }
+		}
+		OR = {
+			evil_public_religion_trigger = no
+			secret_religion = PREV
+			religion = { target = PREV target_type = secret }
+		}
+	}
+	# Otherwise, PREV can interact with those who doesn't follow evil religions
+	trigger_else = {
+		evil_public_religion_trigger = no
+	}
+}
+can_positive_interact_with_prev_publicly_trigger = {
+	# PREV can interact with those who shares PREV's religion publicly
+	trigger_if = {
+		limit = {
+			PREV = { evil_public_religion_trigger = yes }
+		}
+		religion = PREV
+	}
+	# Otherwise, PREV can interact with those who doesn't follow evil religions
+	trigger_else = {
+		evil_public_religion_trigger = no
 	}
 }

--- a/decisions/wc_test_decisions.txt
+++ b/decisions/wc_test_decisions.txt
@@ -486,7 +486,8 @@ targetted_decisions = {
 		}
 		potential = { always = yes }
 		allow = {
-			immortal = yes
+			ROOT = { FROM = { can_positive_interact_with_prev_hiddenly_trigger = yes } }
+			FROM = { ROOT = { can_positive_interact_with_prev_hiddenly_trigger = yes } }
 		}
 		effect = {
 			remove_title = job_spiritual


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Scripting changelog (ignore if you can't read CK2 script):
- Added a few new triggers: `evil_secret_religion_trigger`, `can_positive_interact_with_prev_hiddenly_trigger`, `can_positive_interact_with_prev_publicly_trigger`. They use **trigger_if** logic, so it's better to take a look at the script itself. I added comments.
- Used these new triggers in `can_be_appointed_trigger`, `can_improve_relations_with_root_trigger`, `can_improve_relations_with_from_trigger`. So it affects appointing councilors and sending the chancellor to improve relations.

## How to test:
I changed `test_100` decision to test `can_positive_interact_with_prev_hiddenly_trigger`. To enable it, you've to write `event test.1` in the console and click Yes.

Note: in `test_100`, if `ROOT` can interact with `FROM`, `FROM` must be able to interact with `ROOT`.