### PR TITLE
can_has_sexual_relation_with_prev Issue

### DIFF
--- a/events/HF_coronation_events.txt
+++ b/events/HF_coronation_events.txt
@@ -10161,17 +10161,14 @@ character_event = {
 				30 = {  } 
 				40 = { #Court Love
 					trigger = { 
+						# Warcraft
+						event_target:coronation_knight = { can_has_sexual_relation_with_prev = yes }
+						
 						is_female = yes
 						is_adult = yes
 						NOT = { num_of_lovers = 3 }
 					}
 
-					# Warcraft
-					modifier = { 
-						factor = 0
-						event_target:coronation_knight = { can_has_sexual_relation_with_prev = yes }
-					}
-					
 					modifier = { 
 						factor = 1.5
 						has_fair_trait_trigger = yes

--- a/events/HF_sway_events.txt
+++ b/events/HF_sway_events.txt
@@ -14181,8 +14181,7 @@ character_event = {
 				} 
 				10 = { 
 					# Warcraft
-					modifier = { 
-						factor = 0
+					trigger = {
 						FROM = { can_has_sexual_relation_with_prev = yes }
 					}
 

--- a/events/mnm_monastic_orders_events.txt
+++ b/events/mnm_monastic_orders_events.txt
@@ -4899,12 +4899,14 @@ character_event = {
 			hidden_tooltip = {
 				random_list = {
 					10 = {
+						# Warcraft
+						trigger = {
+							event_target:monastic_friend = { can_has_sexual_relation_with_prev = yes }
+						}
+						
 						modifier = {
 							factor = 0
 							OR = {
-								# Warcraft
-								event_target:monastic_friend = { can_has_sexual_relation_with_prev = no }
-
 								trait = chaste
 								trait = celibate
 							}

--- a/events/rip_flavor_events.txt
+++ b/events/rip_flavor_events.txt
@@ -532,8 +532,7 @@ character_event = {
 		random_list = {
 			10 = { # Physician seduces and impregnates your spouse
 				# Warcraft
-				modifier = {
-					factor = 0
+				trigger = {
 					event_target:spouse_target = {
 						can_has_children_trigger = yes
 						event_target:physician_target = {


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Script changelog:
- Fixed #1241 issue and a few more where `can_has_sexual_relation_with_prev` triggers were broken inside `modifier` blocks and allowed some effects only for incompatible races instead. Fixed by moving the said triggers inside `trigger` blocks with more clear condition logic.