### PR TITLE
Changed holy sites to Ulduar and same for yogg-saron's herald title capital

### DIFF
--- a/common/landed_titles/wc_titular_titles.txt
+++ b/common/landed_titles/wc_titular_titles.txt
@@ -1491,7 +1491,7 @@ e_herald_yoggsaron = {
 	color = { 243 180 17 }
 	color2={ 255 255 255 }
 
-	capital = 876 # c_foot_steppes
+	capital = 858 # c_ulduar
 	culture = nraqi
 	religion = old_gods_worship
 	dignity = 1000

--- a/common/landed_titles/z_holy_sites.txt
+++ b/common/landed_titles/z_holy_sites.txt
@@ -406,7 +406,7 @@ c_gnomeregan = {
 c_new_tinkertown = {
 	holy_site = rationalism
 }
-c_foot_steppes = {
+c_ulduar = {
 	holy_site = rationalism
 }
 c_bonefields = {
@@ -440,7 +440,7 @@ c_tolnariv = {
 c_red_desert = {
 	holy_site = mystery_of_the_makers
 }
-c_foot_steppes = {
+c_ulduar = {
 	holy_site = mystery_of_the_makers
 }
 c_bonefields = {
@@ -554,7 +554,7 @@ c_dazaralor = {
 c_ahnqiraj = {
 	holy_site = old_gods_worship
 }
-c_foot_steppes = {
+c_ulduar = {
 	holy_site = old_gods_worship
 }
 c_obsidian_hills = {


### PR DESCRIPTION
## Changelog:
- Changed holy sites from Foot Steppes to Ulduar and same for Yogg-Saron's herald title capital.

## How to test:
- right click herald title and click go to location.