### PR TITLE
Remove barrow dens after conversion

### DIFF
--- a/events/wc_on_action_events.txt
+++ b/events/wc_on_action_events.txt
@@ -160,6 +160,9 @@ character_event = {
 					has_character_modifier = blessing_of_ursoc
 					has_character_modifier = blessing_of_goldrinn
 					has_character_modifier = blessing_of_malorne
+					has_character_modifier = barrow_den_small
+					has_character_modifier = barrow_den_medium
+					has_character_modifier = barrow_den_large
 				}
 			}
 			trigger_if = {
@@ -351,6 +354,9 @@ character_event = {
 			remove_character_modifier = blessing_of_ursoc
 			remove_character_modifier = blessing_of_goldrinn
 			remove_character_modifier = blessing_of_malorne
+			remove_character_modifier = barrow_den_small
+			remove_character_modifier = barrow_den_medium
+			remove_character_modifier = barrow_den_large
 		}
 		if = {
 			limit = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Barrow Dens (small, medium, large) are lost upon conversion.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Fixes #1332, adds a modifier check for the barrow dens during conversion (when going away from `druidism_group`) and remove if found.
