### PR TITLE
Github now ignores desktop.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.code-workspace
+desktop.ini


### PR DESCRIPTION
#### Developer changelog:
- Github now ignore desktop.ini. It means that Github no longer will ask you if you want to upload your custom folder settings

<details>
<summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/46576860/78664785-5fe26700-78dd-11ea-949b-b9043b85ca3e.png)
![image](https://user-images.githubusercontent.com/46576860/78664822-74266400-78dd-11ea-9e42-b8c4fa9261c2.png)


</details>