### PR TITLE
Fix for AI summoning of King Ymiron

### DIFF
--- a/decisions/wc_realm_decisions.txt
+++ b/decisions/wc_realm_decisions.txt
@@ -547,7 +547,7 @@ decisions = {
 	awaken_ymiron = {
 		is_high_prio = yes
 		
-		ai_check_interval = 24
+		ai_check_interval = 12
 		
 		only_playable = yes
 		


### PR DESCRIPTION
# Changelog:
- Changed _ai_check_interval_ from 24 months to 12 months for _awaken_ymiron_ decision so AI will actually be able to use it

# How to test:
Play as observer and verify if AI holder of Gjalerbron (Queen Angerboda) in 603 and 605 startdates uses the decision to summon King Ymiron correctly.
