### PR TITLE
Allowing Scarlet Light characters to wear the tabard of the Silver Hand

### DIFF
--- a/common/artifacts/906_wc_artifacts_ceremonial_torso.txt
+++ b/common/artifacts/906_wc_artifacts_ceremonial_torso.txt
@@ -54,7 +54,10 @@ tabard_of_the_silverhand = {
 
 	active = {
 		is_adult = yes
-		religion = holy_light
+		OR = {
+			religion = holy_light
+			religion = scarlet_light
+		}
 	}
 	allowed_gift = {
 		religion_group = holy_light


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Allowed Scarlet Light to wear the tabards of the Silver Hand.

<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
