### PR TITLE
3.2.x broken windows fix

### DIFF
--- a/interface/frontend.gui
+++ b/interface/frontend.gui
@@ -1263,21 +1263,22 @@ guiTypes = {
 					clicksound = menu_click
 				}
 				
-				guiButtonType = {
-					name = "extend_featured_ruler"
-					position = { x = 145 y = -100 }
-					quadTextureSprite = "GFX_featured_ruler_arrow_round_right"
-					Orientation = "UPPER_LEFT"
-					clicksound = click
-				}
+				# Paradox, please don't kill us, we're doing it compatibility with 3.2.1 version
+				# guiButtonType = {
+					# name = "extend_featured_ruler"
+					# position = { x = 145 y = -100 }
+					# quadTextureSprite = "GFX_featured_ruler_arrow_round_right"
+					# Orientation = "UPPER_LEFT"
+					# clicksound = click
+				# }
 				
-				guiButtonType = {
-					name = "extend_browser_window"
-					position = { x = -180 y = -100 }
-					quadTextureSprite = "GFX_featured_ruler_arrow_round_left"
-					Orientation = "UPPER_LEFT"
-					clicksound = click
-				}
+				# guiButtonType = {
+					# name = "extend_browser_window"
+					# position = { x = -180 y = -100 }
+					# quadTextureSprite = "GFX_featured_ruler_arrow_round_left"
+					# Orientation = "UPPER_LEFT"
+					# clicksound = click
+				# }
 				
 				###### TEST BUTTONS ######
 


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Fixed an issue where 2 broken windows appeared in the Main Menu if you used 3.2.x version. Thus the mod is compatible with both 3.3.x and 3.2.x versions.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Try to find broken windows in CK2's main menu. Test both 3.2.x and 3.3.x versions.