### PR TITLE
Fixed #1646 fel night elven and highborn portraits

### DIFF
--- a/decisions/wc_test_decisions.txt
+++ b/decisions/wc_test_decisions.txt
@@ -523,7 +523,7 @@ targetted_decisions = {
 		potential = { always = yes }
 		allow = { always = yes }
 		effect = {
-			FROM = { ROOT = { prev_impregnate_this_effect = yes } }
+			unsafe_impregnate_cuckoo = FROM
 		}
 		revoke_allowed = { always = no }
 		ai_will_do = { factor = 0 }

--- a/interface/portraits/portraits_highborne_sprites.gfx
+++ b/interface/portraits/portraits_highborne_sprites.gfx
@@ -1,17 +1,42 @@
 # hair, mouth, chin, nose, eyes, cheek, ear, neck
 spriteTypes = {
 	
-	############## highborne ##########################
-
+	############## Highborne ##########################
+	#highbornegfx
 	spriteType = {
 		name = "PORTRAIT_highbornegfx_child_male"
 		texturefile = "gfx\\characters\\highborne_child\\highborne_child_male.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}
-	
 	spriteType = {
 		name = "PORTRAIT_highbornegfx_child_female"
+		texturefile = "gfx\\characters\\highborne_child\\highborne_child_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#highbornefelgfx
+	spriteType = {
+		name = "PORTRAIT_highbornefelgfx_child_male"
+		texturefile = "gfx\\characters\\highborne_child\\highborne_child_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_highbornefelgfx_child_female"
+		texturefile = "gfx\\characters\\highborne_child\\highborne_child_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#highborneundeadgfx
+	spriteType = {
+		name = "PORTRAIT_highborneundeadgfx_child_male"
+		texturefile = "gfx\\characters\\highborne_child\\highborne_child_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_highborneundeadgfx_child_female"
 		texturefile = "gfx\\characters\\highborne_child\\highborne_child_female.dds"
 		noOfFrames = 1
 		norefcount = yes

--- a/interface/portraits/portraits_highelf_sprites.gfx
+++ b/interface/portraits/portraits_highelf_sprites.gfx
@@ -2,7 +2,7 @@
 spriteTypes = {
 
 	############## highelf ##########################
-
+	#highelfgfx
 	spriteType = {
 		name = "PORTRAIT_highelfgfx_child_male"
 		texturefile = "gfx\\characters\\highelf_child\\highelf_child_male.dds"
@@ -15,6 +15,7 @@ spriteTypes = {
 		noOfFrames = 1
 		norefcount = yes
 	}
+	#highelffelgfx
 	spriteType = {
 		name = "PORTRAIT_highelffelgfx_child_male"
 		texturefile = "gfx\\characters\\highelf_child\\bloodelf_child_male.dds"
@@ -24,6 +25,32 @@ spriteTypes = {
 	spriteType = {
 		name = "PORTRAIT_highelffelgfx_child_female"
 		texturefile = "gfx\\characters\\highelf_child\\bloodelf_child_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#highelfundeadgfx
+	spriteType = {
+		name = "PORTRAIT_highelfundeadgfx_child_male"
+		texturefile = "gfx\\characters\\highelf_child\\highelf_child_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_highelfundeadgfx_child_female"
+		texturefile = "gfx\\characters\\highelf_child\\highelf_child_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#highelflightgfx
+	spriteType = {
+		name = "PORTRAIT_highelflightgfx_child_male"
+		texturefile = "gfx\\characters\\highelf_child\\highelf_child_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_highelflightgfx_child_female"
+		texturefile = "gfx\\characters\\highelf_child\\highelf_child_female.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}

--- a/interface/portraits/portraits_highelfdemon_sprites.gfx
+++ b/interface/portraits/portraits_highelfdemon_sprites.gfx
@@ -1,17 +1,15 @@
 spriteTypes = {
-	
-############## highelfdemon ##########################
-
+	############## highelfdemon ##########################
+	#highelfdemongfx
 	spriteType = {
 		name = "PORTRAIT_highelfdemongfx_child_male"
-		texturefile = "gfx\\characters\\highelfdemon\\highelfdemon_male_base_1.dds"
+		texturefile = "gfx\\characters\\highelf_child\\bloodelf_child_male.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}
-	
 	spriteType = {
 		name = "PORTRAIT_highelfdemongfx_child_female"
-		texturefile = "gfx\\characters\\highelfdemon\\highelfdemon_female_base_1.dds"
+		texturefile = "gfx\\characters\\highelf_child\\bloodelf_child_female.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}

--- a/interface/portraits/portraits_human_sprites.gfx
+++ b/interface/portraits/portraits_human_sprites.gfx
@@ -1,8 +1,8 @@
 # hair, mouth, chin, nose, eyes, cheek, ear, neck
 spriteTypes = {
 
-############## human ##########################
-
+	############## human ##########################
+	#humanwhitegfx
 	spriteType = {
 		name = "PORTRAIT_humanwhitegfx_child_male"
 		texturefile = "gfx\\characters\\human_child\\human_child_white_male.dds"
@@ -10,7 +10,6 @@ spriteTypes = {
 		norefcount = yes
 		can_be_lowres = yes
 	}
-
 	spriteType = {
 		name = "PORTRAIT_humanwhitegfx_child_female"
 		texturefile = "gfx\\characters\\human_child\\human_child_white_female.dds"
@@ -19,6 +18,7 @@ spriteTypes = {
 		can_be_lowres = yes
 	}
 
+	#humantangfx
 	spriteType = {
 		name = "PORTRAIT_humantangfx_child_male"
 		texturefile = "gfx\\characters\\human_child\\human_child_tan_male.dds"
@@ -26,7 +26,6 @@ spriteTypes = {
 		norefcount = yes
 		can_be_lowres = yes
 	}
-
 	spriteType = {
 		name = "PORTRAIT_humantangfx_child_female"
 		texturefile = "gfx\\characters\\human_child\\human_child_tan_female.dds"
@@ -35,6 +34,7 @@ spriteTypes = {
 		can_be_lowres = yes
 	}
 
+	#humanblackgfx
 	spriteType = {
 		name = "PORTRAIT_humanblackgfx_child_male"
 		texturefile = "gfx\\characters\\human_child\\human_child_black_male.dds"
@@ -42,7 +42,6 @@ spriteTypes = {
 		norefcount = yes
 		can_be_lowres = yes
 	}
-
 	spriteType = {
 		name = "PORTRAIT_humanblackgfx_child_female"
 		texturefile = "gfx\\characters\\human_child\\human_child_black_female.dds"
@@ -51,6 +50,7 @@ spriteTypes = {
 		can_be_lowres = yes
 	}
 
+	#humanundeadgfx
 	spriteType = {
 		name = "PORTRAIT_humanundeadgfx_child_male"
 		texturefile = "gfx\\characters\\human_child\\human_child_undead_male.dds"
@@ -58,10 +58,41 @@ spriteTypes = {
 		norefcount = yes
 		can_be_lowres = yes
 	}
-
 	spriteType = {
 		name = "PORTRAIT_humanundeadgfx_child_female"
 		texturefile = "gfx\\characters\\human_child\\human_child_undead_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+		can_be_lowres = yes
+	}
+	
+	#humandemongfx
+	spriteType = {
+		name = "PORTRAIT_humandemongfx_child_male"
+		texturefile = "gfx\\characters\\human_child\\human_child_white_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+		can_be_lowres = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_humandemongfx_child_female"
+		texturefile = "gfx\\characters\\human_child\\human_child_white_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+		can_be_lowres = yes
+	}
+	
+	#humandemongfx
+	spriteType = {
+		name = "PORTRAIT_humanvoidgfx_child_male"
+		texturefile = "gfx\\characters\\human_child\\human_child_white_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+		can_be_lowres = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_humanvoidgfx_child_female"
+		texturefile = "gfx\\characters\\human_child\\human_child_white_female.dds"
 		noOfFrames = 1
 		norefcount = yes
 		can_be_lowres = yes

--- a/interface/portraits/portraits_nightelf_sprites.gfx
+++ b/interface/portraits/portraits_nightelf_sprites.gfx
@@ -1,17 +1,41 @@
 # hair, mouth, chin, nose, eyes, cheek, ear, neck
 spriteTypes = {
-	
-############## nightelf ##########################
-
+	############## Night Elves ##########################
+	#nightelfgfx
 	spriteType = {
 		name = "PORTRAIT_nightelfgfx_child_male"
 		texturefile = "gfx\\characters\\nightelf_child\\nightelf_male_child.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}
-	
 	spriteType = {
 		name = "PORTRAIT_nightelfgfx_child_female"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_female_child.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#nightelffelgfx
+	spriteType = {
+		name = "PORTRAIT_nightelffelgfx_child_male"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_male_child.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_nightelffelgfx_child_female"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_female_child.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	#nightelfundeadgfx
+	spriteType = {
+		name = "PORTRAIT_nightelfundeadgfx_child_male"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_male_child.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "PORTRAIT_nightelfundeadgfx_child_female"
 		texturefile = "gfx\\characters\\nightelf_child\\nightelf_female_child.dds"
 		noOfFrames = 1
 		norefcount = yes
@@ -120,7 +144,7 @@ spriteTypes = {
 		norefcount = yes
 	}
 
-#### nightelf FEMALE ####
+	#### nightelf FEMALE ####
 
 	#Clothes
 	spriteType = {

--- a/interface/portraits/portraits_nightelfdemon_sprites.gfx
+++ b/interface/portraits/portraits_nightelfdemon_sprites.gfx
@@ -3,15 +3,15 @@ spriteTypes = {
 ############## nightelfdemon ##########################
 
 	spriteType = {
-		name = "PORTRAIT_nightelfdemonfgfx_child_male"
-		texturefile = "gfx\\characters\\nightelfdemon\\nightelfdemon_male_base_1.dds"
+		name = "PORTRAIT_nightelfdemongfx_child_male"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_male_child.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}
 	
 	spriteType = {
-		name = "PORTRAIT_nightelfdemonfgfx_child_female"
-		texturefile = "gfx\\characters\\nightelfdemon\\nightelfdemon_female_base_1.dds"
+		name = "PORTRAIT_nightelfdemongfx_child_female"
+		texturefile = "gfx\\characters\\nightelf_child\\nightelf_female_child.dds"
 		noOfFrames = 1
 		norefcount = yes
 	}

--- a/localisation/00_zuwc_united_localisation.csv
+++ b/localisation/00_zuwc_united_localisation.csv
@@ -2981,8 +2981,8 @@ EVTDESC_WCTRO_500;You immerse your body in a pool with shadowflame decoction. Th
 EVTDESC_WCREL_6000_kaldorei_religion;Elune is a complicated goddess. She is generous and just, kind, but vindictive. Just like us she has light and dark sides. Her light aspect, called the Moon Mother, favours priests and diplomats who prevent meaningless bloodshed. Her dark aspect, called the Night Warrior, favours nightblades and warriors who are ready to sacrifice everything in the name of her justice.;;Elune ist eine komplizierte Göttin. Sie ist großzügig und gerecht, freundlich, aber rachsüchtig. Genau wie wir hat sie helle und dunkle Seiten. Ihr heller Aspekt, Mutter Mond, begünstigt Priester und Diplomaten, die sinnloses Blutvergießen verhindern. Ihr dunkler Aspekt, Nachtkrieger genannt, begünstigt Nachtklingen und Krieger, die bereit sind, im Namen ihrer Gerechtigkeit alles zu opfern.;;;;;;;;;;;x
 light_elune_branch_OPTION;I'll be the heart of Elune.;;Ich werde das Herz von Elune sein.;;;;;;;;;;;x
 dark_elune_branch_OPTION;I'll be the hand of Elune.;;Ich werde die Hand von Elune sein.;;;;;;;;;;;x
-;;;;;;;;;;;;;;x
-;;;;;;;;;;;;;;x
+impregnate_deci;Impregnate;;;;;;;;;;;;;x
+impregnate_deci_desc;§Y[From.GetBestName]§! impregnates §Y[Root.GetBestName]§!.;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x
 ;;;;;;;;;;;;;;x


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- Fixed an issue where fel-corrupted night elven and highborn children had human portraits.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Steps:
- Play male night elf or highborn.
- `event test.1` and click ON.
- Use `event WCFEL.9950` to get **Fel Corruption**.
- Click **Present Debutante** in the decisions.
- Right-click the summoned female, click **Impregnate**.
- `give_birth <Her ID>`
- Check the portrait of the born child.
