### PR TITLE
Drust title fix

### DIFF
--- a/common/dynasties/70000_vrykul.txt
+++ b/common/dynasties/70000_vrykul.txt
@@ -231,7 +231,7 @@
 
 #drust
 70200 = { name = "Inath" culture = drust }
-70201 = { name = "Tul" culture = drust }
+70201 = { name = "Vigo" culture = drust }
 70202 = { name = "Jormun" culture = drust }
 70203 = { name = "Koval" culture = drust }
 70204 = { name = "Osigr" culture = drust }

--- a/events/wc_crisis_events.txt
+++ b/events/wc_crisis_events.txt
@@ -359,7 +359,7 @@ narrative_event = {
 		set_global_flag = drust_incursion_happened		# Locks the crisis opening event if it didn't happen
 		
 		create_character = {
-			name = Gorak
+			name = Tul
 			dynasty = 70201
 			culture = drust
 			religion = throsic

--- a/localisation/00_wc_ruler_titles_castle.csv
+++ b/localisation/00_wc_ruler_titles_castle.csv
@@ -185,10 +185,10 @@ king_female_wastewander;Warlord;;Kriegsherrin;;;;;;;;;;;x
 kingdom_of_wastewander;Warlordship of;;Kriegsherrschaft von;;;;;;;;;;;x
 kingdom_wastewander;Warlordship;;Kriegsherrschaft;;;;;;;;;;;x
 # drust;;;;;;;;;;;;;;x
-king_drust;Gorak;;;;;;;;;;;;;
-king_female_drust;Gorak;;;;;;;;;;;;;
-kingdom_of_drust;Gorakdom of;;;;;;;;;;;;;
-kingdom_drust;Gorakdom;;;;;;;;;;;;;
+king_drust;Gorak;;Gorak;;;;;;;;;;;
+king_female_drust;Goraka;;Goraka;;;;;;;;;;;
+kingdom_of_drust;Gorakdom of;;Goraktum von;;;;;;;;;;;
+kingdom_drust;Gorakdom;;Goraktum;;;;;;;;;;;
 duke_drust;Ingra;;Ingra;;;;;;;;;;;x
 duke_female_drust;Ingra;;Ingra;;;;;;;;;;;x
 duchy_drust;Ingradom;;Ingratum;;;;;;;;;;;x

--- a/localisation/00_wc_ruler_titles_castle.csv
+++ b/localisation/00_wc_ruler_titles_castle.csv
@@ -185,6 +185,10 @@ king_female_wastewander;Warlord;;Kriegsherrin;;;;;;;;;;;x
 kingdom_of_wastewander;Warlordship of;;Kriegsherrschaft von;;;;;;;;;;;x
 kingdom_wastewander;Warlordship;;Kriegsherrschaft;;;;;;;;;;;x
 # drust;;;;;;;;;;;;;;x
+king_drust;Gorak;;;;;;;;;;;;;
+king_female_drust;Gorak;;;;;;;;;;;;;
+kingdom_of_drust;Gorakdom of;;;;;;;;;;;;;
+kingdom_drust;Gorakdom;;;;;;;;;;;;;
 duke_drust;Ingra;;Ingra;;;;;;;;;;;x
 duke_female_drust;Ingra;;Ingra;;;;;;;;;;;x
 duchy_drust;Ingradom;;Ingratum;;;;;;;;;;;x

--- a/localisation/00_wc_ruler_titles_tribal.csv
+++ b/localisation/00_wc_ruler_titles_tribal.csv
@@ -47,6 +47,10 @@ tribal_baron_female_dryad_group;Tender;Sylvenière;Jüngling;;;;;;;;;;;x
 tribal_barony_of_dryad_group;Refuge of;Refuge de;Zuflucht von;;;;;;;;;;;x
 tribal_barony_dryad_group;Refuge;Refuge;Zuflucht;;;;;;;;;;;x
 # drust;;;;;;;;;;;;;;x
+tribal_king_drust;Gorak;;;;;;;;;;;;;
+tribal_king_female_drust;Gorak;;;;;;;;;;;;;
+tribal_kingdom_of_drust;Gorakdom of;;;;;;;;;;;;;
+tribal_kingdom_drust;Gorakdom;;;;;;;;;;;;;
 tribal_duke_drust;Ingra;;Ingra;;;;;;;;;;;x
 tribal_duke_female_drust;Ingra;;Ingra;;;;;;;;;;;x
 tribal_duchy_of_drust;Ingradom of;;Ingratum von;;;;;;;;;;;x

--- a/localisation/00_wc_ruler_titles_tribal.csv
+++ b/localisation/00_wc_ruler_titles_tribal.csv
@@ -47,10 +47,10 @@ tribal_baron_female_dryad_group;Tender;Sylvenière;Jüngling;;;;;;;;;;;x
 tribal_barony_of_dryad_group;Refuge of;Refuge de;Zuflucht von;;;;;;;;;;;x
 tribal_barony_dryad_group;Refuge;Refuge;Zuflucht;;;;;;;;;;;x
 # drust;;;;;;;;;;;;;;x
-tribal_king_drust;Gorak;;;;;;;;;;;;;
-tribal_king_female_drust;Gorak;;;;;;;;;;;;;
-tribal_kingdom_of_drust;Gorakdom of;;;;;;;;;;;;;
-tribal_kingdom_drust;Gorakdom;;;;;;;;;;;;;
+tribal_king_drust;Gorak;;Gorak;;;;;;;;;;;
+tribal_king_female_drust;Goraka;;Goraka;;;;;;;;;;;
+tribal_kingdom_of_drust;Gorakdom of;;Goraktum von;;;;;;;;;;;
+tribal_kingdom_drust;Gorakdom;;Goraktum;;;;;;;;;;;
 tribal_duke_drust;Ingra;;Ingra;;;;;;;;;;;x
 tribal_duke_female_drust;Ingra;;Ingra;;;;;;;;;;;x
 tribal_duchy_of_drust;Ingradom of;;Ingratum von;;;;;;;;;;;x


### PR DESCRIPTION
## Changelog:
- Drust kings and queens are now properly referred to as Goraks.
- Changed Gorak Tul's naming convention to have his first name as Tul. His dynasty was renamed Vigo.

## TODO:
- Add German localization (@arithon)

# How to test:
Spawn Gorak Tul by typing `event WCCRS.130` in console and verify if the title (Gorak), name (Tul) and dynasty name (Vigo) are correct. Alternatively pick a character that is a king and change his culture to Drust by typing in `culture drust` and verify whether his title properly changes to Gorak.
