### PR TITLE
Pandaria holy sites

### DIFF
--- a/common/landed_titles/z_holy_sites.txt
+++ b/common/landed_titles/z_holy_sites.txt
@@ -1,15 +1,10 @@
 ### arakkoa_religion_group ###
-### pandaren_religion_group ###
 ### nerubian_religion_group ###
 c_orgrimmar = {
 	# arakkoa_religion_group
 	holy_site = rukhmar_worship
 	holy_site = sethekk_worship
 	holy_site = anzu_worship
-
-	# pandaren_religion_group
-	holy_site = august_celestials
-	holy_site = jinyu_beliefs
 	
 	# nerubian_religion_group
 	holy_site = spider_philosophy
@@ -20,10 +15,6 @@ c_stormwind = {
 	holy_site = sethekk_worship
 	holy_site = anzu_worship
 
-	# pandaren_religion_group
-	holy_site = august_celestials
-	holy_site = jinyu_beliefs
-
 	# nerubian_religion_group
 	holy_site = spider_philosophy
 }
@@ -32,10 +23,6 @@ c_zulfarrak = {
 	holy_site = rukhmar_worship
 	holy_site = sethekk_worship
 	holy_site = anzu_worship
-
-	# pandaren_religion_group
-	holy_site = august_celestials
-	holy_site = jinyu_beliefs
 
 	# nerubian_religion_group
 	holy_site = spider_philosophy
@@ -46,10 +33,6 @@ c_dazaralor = {
 	holy_site = sethekk_worship
 	holy_site = anzu_worship
 
-	# pandaren_religion_group
-	holy_site = august_celestials
-	holy_site = jinyu_beliefs
-
 	# nerubian_religion_group
 	holy_site = spider_philosophy
 }
@@ -58,10 +41,6 @@ c_ironforge = {
 	holy_site = rukhmar_worship
 	holy_site = sethekk_worship
 	holy_site = anzu_worship
-
-	# pandaren_religion_group
-	holy_site = august_celestials
-	holy_site = jinyu_beliefs
 
 	# nerubian_religion_group
 	holy_site = spider_philosophy
@@ -471,7 +450,7 @@ c_red_desert = {
 c_ulduar = {
 	holy_site = mystery_of_the_makers
 }
-c_bonefields = {
+c_mogushan = {
 	holy_site = mystery_of_the_makers
 }
 c_dun_niffelem = {
@@ -576,7 +555,7 @@ c_crestfall = {
 c_sagehold = {
 	holy_site = old_gods_worship
 }
-c_dazaralor = {
+c_zulnazman = {
 	holy_site = old_gods_worship
 }
 c_ahnqiraj = {
@@ -585,7 +564,7 @@ c_ahnqiraj = {
 c_ulduar = {
 	holy_site = old_gods_worship
 }
-c_obsidian_hills = {
+c_lulkail = {
 	holy_site = old_gods_worship
 }
 
@@ -609,4 +588,38 @@ c_gjalerbron = {
 c_ymirheim = {
 	holy_site = odyn
 	holy_site = helya
+}
+
+### pandaren_religion_group ###
+# august_celestials
+c_dawnblossom = {
+	holy_site = august_celestials
+}
+c_niuzao = {
+	holy_site = august_celestials
+}
+c_chi_ji = {
+	holy_site = august_celestials
+}
+c_yulon = {
+	holy_site = august_celestials
+}
+c_xuen = {
+	holy_site = august_celestials
+}
+# waterspeaker
+c_pearlfin = {
+	holy_site = waterspeaker
+}
+c_niuzao = {
+	holy_site = waterspeaker
+}
+c_chi_ji = {
+	holy_site = waterspeaker
+}
+c_yulon = {
+	holy_site = waterspeaker
+}
+c_xuen = {
+	holy_site = waterspeaker
 }

--- a/common/landed_titles/z_holy_sites.txt
+++ b/common/landed_titles/z_holy_sites.txt
@@ -450,7 +450,7 @@ c_red_desert = {
 c_ulduar = {
 	holy_site = mystery_of_the_makers
 }
-c_mogushan = {
+c_nalaksha = {
 	holy_site = mystery_of_the_makers
 }
 c_dun_niffelem = {


### PR DESCRIPTION
<!--
A changelog where you can describe more complicated things to other developers and testers.
-->
## Developer changelog:
- All the Chi religions have holy sites in Pandaria now.
- The Titanic religion has a holy site in Nalak'sha where the Engine of Nalak'sha is located.
- The Shath'gral religion has a holy site in Lul'kali where the Heart of Y'Shaarj is located.
