### PR TITLE
Sunwell religious head bugfix

### DIFF
--- a/history/titles/c_falthrien.txt
+++ b/history/titles/c_falthrien.txt
@@ -4,8 +4,9 @@
 	holder = 42002
 	law = succ_primogeniture
 }
-250.1.1={
-	holder = 42304
+381.11.25={
+	holder = 42034
+	liege = d_sunstrider_isle
 }
 #90% of elves killed by the Scourge
 603.9.1={
@@ -14,8 +15,4 @@
 			add_max_depopulation_effect = yes
 		}
 	}
-}
-604.1.1={
-	holder = 42034
-	liege = d_sunstrider_isle
 }


### PR DESCRIPTION
## Developer changelog:
- Belo'vir Salonar (`ID 42304`) should now properly be a theocratic ruler, as suitable for a religious head.
- County of Falthrien is now properly in the hands of the local ruler (`ID 42034`)

# How to test:
- Please verify if Belo'vir Salonar is properly a Magocracy ruler of Sunwell Plateau (583 and 603 startdates).
