### PR TITLE
Lightbound Icon Fix

### DIFF
--- a/common/religions/light_group.txt
+++ b/common/religions/light_group.txt
@@ -223,8 +223,8 @@ light_group = {
 	lightbound = {
 		graphical_culture = westerngfx
 
-		icon = 59
-		heresy_icon = 60
+		icon = 68
+		heresy_icon = 69
 		
 		color = { 250 225 170 }
 		parent = naaru


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Fixed an issue the Lightbound heresy icon having a wolven head as an icon.
