### PR TITLE
Pandaria Monks

### DIFF
--- a/common/scripted_triggers/wc_class_scripted_triggers.txt
+++ b/common/scripted_triggers/wc_class_scripted_triggers.txt
@@ -1907,6 +1907,7 @@ allow_monk_trigger = {
 				}
 				is_priest = yes
 				controls_religion = yes
+				government = order_government
 			}
 		}
 	}

--- a/events/wc_startup_events.txt
+++ b/events/wc_startup_events.txt
@@ -56,12 +56,11 @@ character_event = {
 					society_member_of = sisterhood_of_elune
 				}
 			}
-			is_lowborn = yes
-			
 			OR = {
-				is_ruler = no
-				is_theocracy = yes
-				tier = BARON
+				is_playable = no
+				is_priest = yes
+				controls_religion = yes
+				government = order_government
 			}
 		}
 		

--- a/history/characters/500000_pandaren.txt
+++ b/history/characters/500000_pandaren.txt
@@ -893,6 +893,9 @@
 	add_trait=mastermind_theologian add_trait=brave add_trait=envious add_trait=arbitrary 
 	father=500078	#Hao
 	535.8.13={ birth=yes add_trait=creature_pandaren }
+	555.1.1={
+		add_trait=class_monk_8
+	}
 	585.9.3={ death=yes }
 }
 500083={
@@ -936,6 +939,9 @@
 	add_trait=grey_eminence add_trait=patient add_trait=diligent add_trait=temperate add_trait=chaste 
 	father=500082	#Dan
 	563.12.23={ birth=yes add_trait=creature_pandaren }
+	583.1.1={
+		add_trait=class_monk_9
+	}
 	648.5.13={ death=yes }
 }
 
@@ -1902,6 +1908,9 @@
 	martial=6 diplomacy=7 stewardship=6 intrigue=7 learning=4
 	add_trait=scholarly_theologian add_trait=cynical add_trait=arbitrary add_trait=cruel add_trait=brave 
 	1.2.7={ birth=yes add_trait=creature_pandaren }
+	20.1.1={
+		add_trait=class_hunter_5
+	}
 	57.5.25={ death=yes }
 }
 500186={
@@ -3910,7 +3919,6 @@
 
 #dynasty = 170006 (Autumnlight)
 # Kun Autumnlight (lore character)
-# Add monk class when available
 500370={
 	name=Kun
 	dynasty=170006
@@ -3919,6 +3927,9 @@
 	martial=8 diplomacy=4 stewardship=5 intrigue=6 learning=8
 	add_trait=martial_cleric add_trait=content add_trait=proud add_trait=diligent
 	520.7.3={ birth=yes add_trait=creature_pandaren }
+	540.1.1={
+		add_trait=class_monk_5
+	}
 	611.5.12={ death=yes }
 }
 # Anji Autumnlight (lore character)
@@ -7797,7 +7808,6 @@
 }
 #dynasty = 170014 (Niao)
 # Lore character
-# Add monk class when available
 500727={
 	name=Xiao
 	dynasty=170014
@@ -7809,6 +7819,7 @@
 	add_trait=zealous 
 	568.5.20={ birth=yes add_trait=creature_pandaren }
 	583.1.1={
+		add_trait=class_monk_5
 		give_nickname = nick_the_nightingale
 	}
 	611.8.21={ death=yes }
@@ -41872,6 +41883,9 @@
 	add_trait=lustful add_trait=zealous
 	father=500177	#Jung
 	545.7.19={ birth=yes add_trait=creature_pandaren }
+	565.1.1={
+		add_trait=class_monk_6
+	}
 	# Booty Bay
 	583.1.1={
 		employer = 64000	# Jazikrax Revilgaz
@@ -41918,6 +41932,9 @@
 	add_trait=mastermind_theologian add_trait=content add_trait=kind add_trait=brave add_trait=gregarious
 	father=500179	#Yun
 	556.8.4={ birth=yes add_trait=creature_pandaren }
+	576.1.1={
+		add_trait=class_monk_8
+	}
 	556.8.5={
 		effect = {
 			if = {
@@ -41958,13 +41975,16 @@
 
 # Li Li Stormstout
 500184={
-	name=Li-Li
+	name="Li Li"
 	female=yes
 	dynasty=170073
 	dna="lmmlllakehb"
 	culture=wandering_pandaren religion=august_celestials
 	father=500181	#Chon Po
 	598.12.19={ birth=yes add_trait=creature_pandaren }
+	614.1.1={
+		add_trait=class_monk_7
+	}
 	598.12.20={
 		effect = {
 			if = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Historical monks have the Monk trait: Dan and Taran Zhu, Kun Autumnlight, Xiao Niao, Mojo Stormstout, Chen Stormstout.
- The leaders and rulers under the Celestial holy orders should have the Monk trait.

<!--
If you need to explain something to testers. Otherwise, delete this part.
-->
# How to test:
Check changes in-game and tell if I forgot someone.
