### PR TITLE
One-eyed Lor'themar

### DIFF
--- a/history/characters/42000_high_elf.txt
+++ b/history/characters/42000_high_elf.txt
@@ -1174,6 +1174,11 @@
 		add_trait=creature_blood_elf
 		culture=blood_elf
 	}
+	#He loses his eye
+	603.10.1={
+		add_trait=one_eyed
+		add_trait=scarred
+	}
 	604.1.1={
 		effect = {
 			set_character_flag = is_regent_lord_flag


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Changelog:
- Lor'themar has one eye and the Scarred trait in the 605th bookmark.
