### PR TITLE
Panda and Old Gods' Balance Tweaks

### DIFF
--- a/common/scripted_score_values/wc_scripted_score_values.txt
+++ b/common/scripted_score_values/wc_scripted_score_values.txt
@@ -539,7 +539,7 @@ prefers_cthun_score = {
 		}
 	}
 	modifier = {
-		factor = 10
+		factor = 100
 		has_cthun_wonder_trigger = yes
 	}
 }
@@ -557,7 +557,7 @@ prefers_yogg_saron_score = {
 		}
 	}
 	modifier = {
-		factor = 10
+		factor = 100
 		has_yogg_saron_wonder_trigger = yes
 	}
 }
@@ -575,7 +575,7 @@ prefers_nzoth_score = {
 		}
 	}
 	modifier = {
-		factor = 10
+		factor = 100
 		has_nzoth_wonder_trigger = yes
 	}
 }

--- a/events/wc_dark_cult_events.txt
+++ b/events/wc_dark_cult_events.txt
@@ -873,16 +873,27 @@ narrative_event = {
 	# I will fulfill the will of the Gods!
 	option = {
 		name = EVTOPTA_WCDAC_5030
+		
 		custom_tooltip = { text = chogall_journey_length }
 		hidden_effect = { remove_old_gods_follower_modifier_effect = yes }
 		add_character_modifier = { name = follower_of_cthun duration = -1 }
 		set_global_flag = twilights_hammer_kalimdor
+		
+		ai_chance = {
+			factor = 75
+		}
+		
 	}
 	option = {
 		name = EVTOPTB_WCDAC_5030
+		
 		custom_tooltip = { text = chogall_journey_length }
 		hidden_effect = { remove_old_gods_follower_modifier_effect = yes }
 		add_character_modifier = { name = follower_of_yogg_saron duration = -1 }
+		
+		ai_chance = {
+			factor = 25
+		}
 	}
 	after = {
 		hidden_effect = { 73 = { province_event = { id = WCDAC.5034 years = 4 } } }

--- a/events/wc_sha_events.txt
+++ b/events/wc_sha_events.txt
@@ -57,6 +57,11 @@ character_event = {
 			factor = 1.5
 			trait = cruel
 		}
+		modifier = {
+			factor = 0.01
+			ai = yes
+			independent = yes
+		}
 		
 		# Less chances, but possible
 		modifier = {


### PR DESCRIPTION
<!--
A basic changelog, goes to patch notes of the next version, so should be as short and informative as possible.
-->
## Script changelog (ignore if you can't read CK2 script):
- The independent AI is less likely to be corrupted by Sha.
- Cho'gall prefers to go Kalimdor than Northrend in the 583 bookmark.
- Increased wonder modifiers in `prefers_<Old God>_score`.