### PR TITLE
Gnoll Wars Startdate - History

### DIFF
--- a/events/wc_gnoll_war_events.txt
+++ b/events/wc_gnoll_war_events.txt
@@ -1,6 +1,7 @@
 namespace = WCGW
 #Gnoll wars
 #velius: requires cleanup
+#commiting this to
 
 #Garfang Bloodline
 character_event = {
@@ -11,14 +12,14 @@ character_event = {
 
 	is_triggered_only = yes
 
-  option = { #Gain Garfang bloodline.
-    name = EVTOPTA_WCGW_100
-    create_bloodline = { type = garfang }
-    if = {
-      limit = { has_nickname = no }
-      give_nickname = nick_the_great_beast
-    }
-  }
+	option = { #Gain Garfang bloodline.
+		name = EVTOPTA_WCGW_100
+		create_bloodline = { type = garfang }
+		if = {
+			limit = { has_nickname = no }
+			give_nickname = nick_the_great_beast
+		}
+	}
 }
 
 #Barathen Bloodline


### PR DESCRIPTION
## Changelog:
TBA

## Developer changelog:
TBA

## Developer Notes:
### EASTERN KINGDOMS:
- The Gnolls under Packlord Garfang wage war against the Kingdom of Stormwind. The exact extent of their territorial control at game start is still to be determined.
- Stromgarde still firmly clings to Durnholde, which serves as a major point of contention between them and Alterac.
- Zul'aman is fractured between various warlords, who are at free-for-all war against each other. The victor becomes the undisputed ruler of the Amani. The high elves are sure to take advantage of the situation, so for Amani players it's imperative to beat every other contender ASAP.
- Gilneas is in the twilight years of rapidly failing Aderician rule and are challenged by the pro-isolationist Greymanes. Depending on the course of events, the Adericians can retain the throne or make way for the Greymanes to take power.
- Lordaeron is on the expansionist path, having fully incorporated the former autonomy of Andorhal in the recent years. Stratholme still remains an autonomous city-state, although it's also close to become incorporated. The high elves have high stakes in control of the territory due to its strategic position as a major port and cultural crossroads between the humans and elves, with the magistracy split between influential dignitaries from both races.
- Southern Silverpine remains a Gilnean fiefdom under Mistmantles, albeit diminished due to border disputes with Lordaeron and now is facing external problems in the form of encroaching murlocs or gnolls.
- Black Morass remains mostly an Atal'ai fiefdom, where the Hakkari thrive undisturbed by the meddling of Gurubashi 'inquisitors', the latter having abandoned the region in between the events of 353-508.
- The Dark Irons are still reeling from the disastrous effects of the War of the Three Hammers, with the last holdouts that refuse to bow before Ragnaros' cohorts being entrenched deeply in the Badlands and northern Searing Gorge.

### KALIMDOR:
- The night elves remain isolationist, without any major territorial changes until 603.
- The centaur of Kalimdor are at their peak during that period, with most of the territory being held by an ambitious Earth-Khan or Therakhan, who is close to establishing a High Khanate.
- Zul'farrak is in control of the majority of Tanaris and the Molten Cay, since Gadgetzan wasn't founded yet. Some Tortollan settlements are close to Un'goro (Thistleshrub Valley) and possibly the southern coast, all of which are vassals/tributaries of the sand trolls.
- Silithus is divided between minor Qiraji warlords, murlocs and some Highborne expeditionaries in the Crystal Vale. Cenarion Hold doesn't exist yet, having been re-established post-Third War (this is also a major historical inaccuracy present currently in other bookmarks).
- The Azuremyst Isles are mostly held by the Furbolg, although it has a small portion of Highborne elves inhabiting the southern portion of Bloodmyst, led by a shady adventurer named Nazzivus.
- Eldre'thalas holds much more territory in Feralas, although it's heavily dependent on the void energies of Immol'thar. A reorganization of the current Highborne sociopolitical structure for all bookmarks is not out of the question (Tortheldrin in particular might be a Voidfarer).
- The future site of Durotar is a Quilboar stronghold that is contested with the harpies.
- The mesas of Thousand Needles serve as a primary area of concentration for the nomadic Tauren in this time period. Shimmering Flats are Farraki border region.
- Mulgore is contested between harpies, quilboar and the Therakhan's centaur horde.
- Uldum's content is covered by a separate PR focusing on reworking the region for all bookmarks ( #1704 )

### NORTHREND:
- The presence of the kvaldir is diminished compared to later startdates, since the burial ground wasn't desecrated by the pirates yet. This may extend to 583 startdate as well.
- Hrothgar's Landing is still known by its former name of Tualiq, and is inhabited by Tuskarr. This may extend to 583 startdate as well.
- Strand of the Ancients (AKA Alduran) is held by the Titanforged.
- Zul'drak's territorial extent is far greater, possibly extending slightly beyond Jintha'kalar.
- A major frost vrykul jarldom is present in Icecrown.
- A war between the Hylndir and Dun Niffelem is in progress. Territorial extent of both sides is yet to be determined.
- The Nerubians are amassing in En'kilah and Naz'anak.

### KEZAN:
- The goblins are infighting and cartels are slowly beginning to form.
- The Zandalari retain a claim on the isle, having been driven off merely ~20 years ago. Small remnants of Zandalari culture are still present.

### KUL TIRAS:
- Stormsong Valley remains in control of the Quilboar tribes. Storm Isle is a major Void stronghold held by the Faceless.

### ZANDALAR:
- Uncertain turmoil in Zul'Nazman, likely a social rift/civil war between the G'huunists and the Hakkari.

### PANDARIA:
- To be determined after release.

## IMPORTANT REGIONS:
- Uldum is covered by ( #1704 )
- Zandalar is covered by  ( #1719 )

## TODO:
### WARNING: MASSIVE LIST
- [ ] Character history
   - [ ] Human
      - [ ] Lordaeronian
      - [ ] Dalaranian
      - [ ] Alteraci
      - [ ] Gilnean
      - [ ] Azerothian
      - [ ] Stromic
      - [ ] Northern
      - [ ] Southern
   - [ ] Dwarven
      - [ ] Bronzebeard
      - [ ] Wildhammer
      - [ ] Dark Iron
    - [ ] High Elven
    - [ ] Troll
      - [ ] Gurubashi
      - [ ] Amani
      - [ ] Drakkari
      - [ ] Farraki
      - [ ] Zandalari
      - [ ] Nazmani
   - [ ] Night Elven
   - [ ] Highborne
   - [ ] Nerglish
      - [ ] Murloc
      - [ ] Gilblin
   - [ ] Centaur
   - [ ] Taur-ahe
      - [ ] Tauren
      - [ ] Taunka
   - [ ] Vrykul
      - [ ] Flesh Vrykul
      - [ ] Frost Vrykul
      - [ ] Kvaldir
   - [ ] Tuskarr
   - [ ] Magnataur
   - [ ] Aqir
      - [ ] Qiraji
      - [ ] Nerubian
   - [ ] Goblin
   - [ ] Quilboar
   - [ ] Harpy
   - [ ] Pygmy
   - [ ] Satyr
   - [ ] Furbolg
   - [ ] Dragonkin

## How to test:
TBA