### PR TITLE
Stone Tol'vir Fertility

### DIFF
--- a/common/traits/wc_race_traits.txt
+++ b/common/traits/wc_race_traits.txt
@@ -2122,6 +2122,7 @@ creature_stone_tolvir = {
 	martial = 2
 	intrigue = -1
 	learning = 2
+	fertility = -10
 	health = 0.1
 
 	ai_ambition = 10		# Imperialists

--- a/interface/portraits/portraits_tolvir_sprites.gfx
+++ b/interface/portraits/portraits_tolvir_sprites.gfx
@@ -17,6 +17,20 @@ spriteTypes = {
 		norefcount = yes
 	}
 	
+	spriteType = {
+		name = "PORTRAIT_stonetolvirgfx_child_male"
+		texturefile = "gfx\\characters\\tolvir_child\\tolvir_child_male.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	
+	spriteType = {
+		name = "PORTRAIT_stonetolvirgfx_child_female"
+		texturefile = "gfx\\characters\\tolvir_child\\tolvir_child_female.dds"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	
 	### tolvir MALE ####
 	
 	spriteType = {


### PR DESCRIPTION
## Changelog:
- Stone Tol'vir are no longer fertile cause they are not made of flesh.
- Added portrait logic for child stonetolvirgfx (placeholder, should not be possible to actually view these)

# How to test:
- Verify if you can have children by playing as stone tol'vir. Try playing Pharaoh Nakhotep of Neferset and gain your stone body during the event chain.